### PR TITLE
Enable support for Structured Stream (preview)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ limitations under the License.
     <scala.binary.version>2.11</scala.binary.version>
     <sonar.projectBaseDir>azure-cosmosdb-spark</sonar.projectBaseDir>
     <scala.test.version>3.0.1</scala.test.version>
-    <spark.version>2.0.2</spark.version>
+    <spark.version>2.1.0</spark.version>
     <slf4j.version>1.7.6</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <tinkerpop.version>3.2.5</tinkerpop.version>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
@@ -129,7 +129,7 @@ object CosmosDBSpark extends LoggingTrait {
     * @tparam D the type of the data in the RDD
     */
   def save[D: ClassTag](rdd: RDD[D], writeConfig: Config): Unit = {
-    var connection = CosmosDBConnection(writeConfig)
+    var connection = new CosmosDBConnection(writeConfig)
     val upsert: Boolean = writeConfig
       .getOrElse(CosmosDBConfig.Upsert, String.valueOf(CosmosDBConfig.DefaultUpsert))
       .toBoolean

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
@@ -145,6 +145,7 @@ object CosmosDBSpark extends LoggingTrait {
       var createDocumentObs: Observable[ResourceResponse[Document]] = null
       var batchSize = 0
       iter.foreach(item => {
+        val document: Document = item.asInstanceOf[Document]
         if (upsert)
           createDocumentObs = connection.upsertDocument(item.asInstanceOf[Document], null)
         else

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/DefaultSource.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/DefaultSource.scala
@@ -69,6 +69,7 @@ class DefaultSource extends RelationProvider
         CosmosDBSpark.save(data, config)
       case Overwrite =>
         var upsertConfig: collection.Map[String, String] = config.asOptions
+        upsertConfig -= CosmosDBConfig.Upsert
         upsertConfig += CosmosDBConfig.Upsert -> String.valueOf(true)
         CosmosDBSpark.save(data, Config(upsertConfig))
       case ErrorIfExists  =>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -51,6 +51,7 @@ object CosmosDBConfig {
   val RollingChangeFeed = "rollingchangefeed"
   val ChangeFeedStartFromTheBeginning = "changefeedstartfromthebeginning"
   val ChangeFeedUseNextToken = "changefeedusenexttoken"
+  val ChangeFeedContinuationToken = "changefeedcontinuationtoken"
   val IncrementalView = "incrementalview"
   val CachingModeParam = "cachingmode"
   val ChangeFeedQueryName = "changefeedqueryname"

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -102,9 +102,7 @@ class CosmosDBRDDIterator(
       if (emitVerboseTraces.isDefined) {
         feedOpts.setEmitVerboseTracesInQuery(emitVerboseTraces.get.toBoolean)
       }
-      // Set target partition ID_PROPERTY
       feedOpts.setPartitionKeyRangeIdInternal(partition.partitionKeyRangeId.toString)
-      feedOpts.setEnableCrossPartitionQuery(true)
       CosmosDBRDDIterator.lastFeedOptions = feedOpts
 
       val queryString = config

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -54,7 +54,8 @@ object CosmosDBRDDIterator {
     * @return       the corresponding global continuation token
     */
   def getCollectionTokens(config: Config): String = {
-    val collectionLink = new CosmosDBConnection(config).collectionLink
+    val connection = new CosmosDBConnection(config)
+    val collectionLink = connection.collectionLink
     val queryName = config
       .get[String](CosmosDBConfig.ChangeFeedQueryName).get
     var tokenString: String = null
@@ -63,8 +64,7 @@ object CosmosDBRDDIterator {
       !changeFeedNextTokens.containsKey(queryName) ||
       !changeFeedNextTokens.get(queryName).containsKey(collectionLink)) {
       val tokenMap = new ConcurrentHashMap[String, String]
-      val conn = new CosmosDBConnection(config)
-      val ranges = conn.getAllPartitions
+      val ranges = connection.getAllPartitions
       var rangeIndex = 0
       ranges.foreach(r => {
         tokenMap.put(rangeIndex.toString, 0.toString)
@@ -76,6 +76,14 @@ object CosmosDBRDDIterator {
     }
 
     tokenString
+  }
+
+  /**
+    * Used for verification purpose only. Clear the next continuation tokens cache to simulate a fresh start.
+    */
+  def resetCollectionContinuationTokens(): Any = {
+    changeFeedTokens = null
+    changeFeedNextTokens = null
   }
 }
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -24,6 +24,7 @@ package com.microsoft.azure.cosmosdb.spark.rdd
 
 import java.io.File
 import java.nio.file.Paths
+import java.util
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -43,8 +44,39 @@ object CosmosDBRDDIterator {
 
   // Map of change feed query name -> collection Rid -> partition range ID -> continuation token
   var changeFeedTokens: ConcurrentMap[String, ConcurrentMap[String, ConcurrentMap[String, String]]] = _
+
   // Map of change feed candidate token for the next batch
   var changeFeedNextTokens: ConcurrentMap[String, ConcurrentMap[String, ConcurrentMap[String, String]]] = _
+
+  /**
+    * Get the next global continuation token for the collection in the provided config
+    * @param config a structured stream configuration with connection details, a query name and a collection name
+    * @return       the corresponding global continuation token
+    */
+  def getCollectionTokens(config: Config): String = {
+    val collectionLink = new CosmosDBConnection(config).collectionLink
+    val queryName = config
+      .get[String](CosmosDBConfig.ChangeFeedQueryName).get
+    var tokenString: String = null
+
+    if (changeFeedNextTokens == null ||
+      !changeFeedNextTokens.containsKey(queryName) ||
+      !changeFeedNextTokens.get(queryName).containsKey(collectionLink)) {
+      val tokenMap = new ConcurrentHashMap[String, String]
+      val conn = new CosmosDBConnection(config)
+      val ranges = conn.getAllPartitions
+      var rangeIndex = 0
+      ranges.foreach(r => {
+        tokenMap.put(rangeIndex.toString, 0.toString)
+        rangeIndex = rangeIndex + 1
+      })
+      tokenString = new ObjectMapper().writeValueAsString(tokenMap)
+    } else {
+      tokenString = new ObjectMapper().writeValueAsString(changeFeedNextTokens.get(queryName).get(collectionLink))
+    }
+
+    tokenString
+  }
 }
 
 class CosmosDBRDDIterator(
@@ -123,6 +155,7 @@ class CosmosDBRDDIterator(
       var collectionTokenMap: ConcurrentMap[String, String] = null
       var collectionNextTokenMap: ConcurrentMap[String, String] = null
 
+      // Initialize the static tokens cache or read it from checkpoint
       def initializeTokenMaps() = {
         if (CosmosDBRDDIterator.changeFeedTokens == null) {
           CosmosDBRDDIterator.synchronized {
@@ -158,6 +191,7 @@ class CosmosDBRDDIterator(
         }
       }
 
+      // Get continuation token for the partition with provided partitionId
       def getContinuationToken(partitionId: String): String = {
         val collectionLink = connection.collectionLink
         val queryName = config
@@ -175,18 +209,27 @@ class CosmosDBRDDIterator(
 
         currentTokens.putIfAbsent(collectionLink, new ConcurrentHashMap[String, String]())
         nextTokens.putIfAbsent(collectionLink, new ConcurrentHashMap[String, String]())
-        collectionTokenMap = currentTokens.get(collectionLink)
-        collectionNextTokenMap = nextTokens.get(collectionLink)
 
-        // Set the current token to next token for the target collection
-        val useNextToken: Boolean = config
-          .get[String](CosmosDBConfig.ChangeFeedUseNextToken)
-          .getOrElse(CosmosDBConfig.DefaultChangeFeedUseNextToken.toString)
-          .toBoolean
-        if (useNextToken) {
-          val nextToken = collectionNextTokenMap.get(partitionId)
-          if (nextToken != null) {
-            collectionTokenMap.put(partitionId, nextToken)
+        val continuationToken = config.get[String](CosmosDBConfig.ChangeFeedContinuationToken)
+        if (continuationToken.isDefined) {
+          // Continuaton token is overriden
+          val emptyTokenMap = new ConcurrentHashMap[String, String]()
+          collectionTokenMap = objectMapper.readValue(continuationToken.get, emptyTokenMap.getClass)
+          collectionNextTokenMap = nextTokens.get(collectionLink)
+        } else {
+          collectionTokenMap = currentTokens.get(collectionLink)
+          collectionNextTokenMap = nextTokens.get(collectionLink)
+
+          // Set the current token to next token for the target collection
+          val useNextToken: Boolean = config
+            .get[String](CosmosDBConfig.ChangeFeedUseNextToken)
+            .getOrElse(CosmosDBConfig.DefaultChangeFeedUseNextToken.toString)
+            .toBoolean
+          if (useNextToken) {
+            val nextToken = collectionNextTokenMap.get(partitionId)
+            if (nextToken != null) {
+              collectionTokenMap.put(partitionId, nextToken)
+            }
           }
         }
 
@@ -194,6 +237,7 @@ class CosmosDBRDDIterator(
         changeFeedContinuation
       }
 
+      // Update the tokens cache as appropriate
       def updateTokens(currentToken: String,
                        nextToken: String,
                        partitionId: String,
@@ -204,7 +248,7 @@ class CosmosDBRDDIterator(
           .getOrElse(CosmosDBConfig.DefaultRollingChangeFeed.toString)
           .toBoolean
 
-        if (currentToken == null || rollingChangeFeed) {
+      if (currentToken == null || rollingChangeFeed) {
           collectionTokenMap.put(partitionId, nextToken)
 
           if (changeFeedCheckpoint) {

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/DataFrameReaderFunctions.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/DataFrameReaderFunctions.scala
@@ -35,6 +35,12 @@ import scala.reflect.runtime.universe._
 
 object DataFrameReaderFunctions {
   private val cachedData: ConcurrentMap[String, DataFrame] = new ConcurrentHashMap[String, DataFrame]()
+
+  def getCacheKey(configMap: collection.Map[String, String]) : String = {
+    val database = configMap.get(CosmosDBConfig.Database)
+    val collection = configMap.get(CosmosDBConfig.Collection)
+    s"dbs/$database/colls/$collection"
+  }
 }
 
 private[spark] case class DataFrameReaderFunctions(@transient dfr: DataFrameReader) extends LoggingTrait {
@@ -87,9 +93,7 @@ private[spark] case class DataFrameReaderFunctions(@transient dfr: DataFrameRead
         .get[String](CosmosDBConfig.CachingModeParam)
         .getOrElse(CosmosDBConfig.DefaultCacheMode.toString))
 
-      database = readConfig.get.getOrElse[String](CosmosDBConfig.Database, StringUtils.EMPTY)
-      collection = readConfig.get.getOrElse[String](CosmosDBConfig.Collection, StringUtils.EMPTY)
-      collectionCacheKey = s"dbs/$database/colls/$collection"
+      collectionCacheKey = DataFrameReaderFunctions.getCacheKey(readConfig.get.asOptions)
     }
 
     if (cachingMode == CachingMode.CACHE) {

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBOffset.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBOffset.scala
@@ -22,8 +22,18 @@
   */
 package com.microsoft.azure.cosmosdb.spark.streaming
 
+import com.microsoft.azure.cosmosdb.spark.LoggingTrait
 import org.apache.spark.sql.execution.streaming.Offset
 
-class CosmosDBOffset extends Offset {
+case class CosmosDBOffset(offset: String)
+  extends Offset
+    with LoggingTrait {
 
+  override def json: String = {
+    offset
+  }
+
+  override def toString(): String = {
+    json
+  }
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBOffset.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBOffset.scala
@@ -1,0 +1,29 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import org.apache.spark.sql.execution.streaming.Offset
+
+class CosmosDBOffset extends Offset {
+
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSink.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSink.scala
@@ -1,0 +1,46 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import com.microsoft.azure.cosmosdb.spark.LoggingTrait
+import com.microsoft.azure.cosmosdb.spark.config.Config
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+import com.microsoft.azure.cosmosdb.spark.schema._
+
+private[spark] class CosmosDBSink(sqlContext: SQLContext,
+                                    configMap: Map[String, String])
+  extends Sink with LoggingTrait {
+
+  private var lastBatchId: Long = -1L
+
+  override def addBatch(batchId: Long, data: DataFrame): Unit = {
+    if (batchId <= lastBatchId) {
+      logDebug(s"Rerun batchId $batchId")
+    } else {
+      lastBatchId = batchId
+    }
+
+    data.write.mode(SaveMode.Append).cosmosDB(Config(configMap))
+  }
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSinkProvider.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSinkProvider.scala
@@ -1,0 +1,42 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import com.microsoft.azure.cosmosdb.spark.LoggingTrait
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
+import org.apache.spark.sql.streaming.OutputMode
+
+private[spark] class CosmosDBSinkProvider extends DataSourceRegister
+  with StreamSinkProvider with LoggingTrait {
+
+  override def shortName(): String = "CosmosDBSinkProvider"
+
+  override def createSink(sqlContext: SQLContext,
+                          parameters: Map[String, String],
+                          partitionColumns: Seq[String],
+                          outputMode: OutputMode): Sink = {
+    new CosmosDBSink(sqlContext, parameters)
+  }
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
@@ -45,6 +45,7 @@ private[spark] class CosmosDBSource(sqlContext: SQLContext,
     val df = sqlContext.read.cosmosDB(Config(streamConfigMap
       .-(CosmosDBConfig.ChangeFeedStartFromTheBeginning)
       .+((CosmosDBConfig.ChangeFeedStartFromTheBeginning, String.valueOf(false)))))
+    df.count()
     df.schema
   }
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
@@ -32,9 +32,11 @@ import com.microsoft.azure.cosmosdb.spark.schema._
 private[spark] class CosmosDBSource(sqlContext: SQLContext,
                                     configMap: Map[String, String])
   extends Source with LoggingTrait {
-  val streamConfig = Config(configMap
-    .-(CosmosDBConfig.RollingChangeFeed)
-    .+((CosmosDBConfig.RollingChangeFeed, String.valueOf(true))))
+  val streamConfig = Config(configMap.
+    -(CosmosDBConfig.ReadChangeFeed).
+    +((CosmosDBConfig.ReadChangeFeed, String.valueOf(true))).
+    -(CosmosDBConfig.RollingChangeFeed).
+    +((CosmosDBConfig.RollingChangeFeed, String.valueOf(true))))
   val changeFeedDf: DataFrame = sqlContext.read.cosmosDB(streamConfig)
 
   override def schema: StructType = changeFeedDf.schema

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
@@ -1,0 +1,49 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import com.microsoft.azure.cosmosdb.spark.LoggingTrait
+import com.microsoft.azure.cosmosdb.spark.config.{Config, CosmosDBConfig}
+import org.apache.spark.sql.execution.streaming.{Offset, Source}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import com.microsoft.azure.cosmosdb.spark.schema._
+
+private[spark] class CosmosDBSource(sqlContext: SQLContext,
+                                    configMap: Map[String, String])
+  extends Source with LoggingTrait {
+  val streamConfig = Config(configMap
+    .-(CosmosDBConfig.RollingChangeFeed)
+    .+((CosmosDBConfig.RollingChangeFeed, String.valueOf(true))))
+  val changeFeedDf: DataFrame = sqlContext.read.cosmosDB(streamConfig)
+
+  override def schema: StructType = changeFeedDf.schema
+
+  override def getOffset: Option[Offset] = Some(new CosmosDBOffset())
+
+  override def getBatch(start: Option[Offset], end: Offset): DataFrame = changeFeedDf
+
+  override def stop(): Unit = {
+    // no op
+  }
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSourceProvider.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSourceProvider.scala
@@ -1,0 +1,61 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import com.microsoft.azure.cosmosdb.spark.LoggingTrait
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.execution.streaming.Source
+import org.apache.spark.sql.sources.{DataSourceRegister, StreamSourceProvider}
+import org.apache.spark.sql.types.StructType
+
+private[spark] class CosmosDBSourceProvider extends DataSourceRegister
+  with StreamSourceProvider with LoggingTrait {
+
+  var cosmosDBSource: CosmosDBSource = _
+
+  override def shortName(): String = "CosmosDBSourceProvider"
+
+  def cosmosDBSource(sqlContext: SQLContext, parameters: Map[String, String]): CosmosDBSource = {
+    this.synchronized({
+      if (cosmosDBSource == null) {
+        cosmosDBSource = new CosmosDBSource(sqlContext, parameters)
+      }
+    })
+    cosmosDBSource
+  }
+
+  override def sourceSchema(sqlContext: SQLContext,
+                            schema: Option[StructType],
+                            providerName: String,
+                            parameters: Map[String, String]): (String, StructType) = {
+    (shortName(), cosmosDBSource(sqlContext, parameters).schema)
+  }
+
+  override def createSource(sqlContext: SQLContext,
+                            metadataPath: String,
+                            schema: Option[StructType],
+                            providerName: String,
+                            parameters: Map[String, String]): Source = {
+    cosmosDBSource(sqlContext, parameters)
+  }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,16 @@
+# this is the log4j configuration for tests
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# Set HTTP components' logger to INFO
+log4j.category.org.apache.http=INFO
+log4j.category.org.apache.http.wire=INFO
+log4j.category.org.apache.http.headers=INFO
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d %5X{pid} [%t] %-5p %c - %m%n

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -8,6 +8,8 @@ log4j.category.org.apache.http=INFO
 log4j.category.org.apache.http.wire=INFO
 log4j.category.org.apache.http.headers=INFO
 
+log4j.category.com.microsoft.azure.documentdb=INFO
+
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 

--- a/src/test/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBDataFrameSpec.scala
+++ b/src/test/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBDataFrameSpec.scala
@@ -27,7 +27,7 @@ import java.sql.{Date, Timestamp}
 import java.util.concurrent.TimeUnit
 
 import com.microsoft.azure.cosmosdb.spark.config.{Config, CosmosDBConfig}
-import com.microsoft.azure.cosmosdb.spark.rdd.CosmosDBRDD
+import com.microsoft.azure.cosmosdb.spark.rdd.{CosmosDBRDD, CosmosDBRDDIterator}
 import com.microsoft.azure.cosmosdb.spark.streaming.{CosmosDBSinkProvider, CosmosDBSourceProvider}
 import com.microsoft.azure.cosmosdb.spark.{RequiresCosmosDB, _}
 import com.microsoft.azure.documentdb._
@@ -553,7 +553,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     val host = CosmosDBDefaults().EMULATOR_ENDPOINT
     val key = CosmosDBDefaults().EMULATOR_MASTERKEY
     val databaseName = CosmosDBDefaults().DATABASE_NAME
-    val sinkCollection = "cosmosdbsink"
+    val sinkCollection = String.format("CosmosDBSink-%s", System.currentTimeMillis().toString)
     val streamingTimeMs = TimeUnit.SECONDS.toMillis(10)
     val streamingGapMs = TimeUnit.SECONDS.toMillis(10)
     val insertIntervalMs = TimeUnit.SECONDS.toMillis(1) / 2
@@ -573,26 +573,45 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     documentCollection.setId(sinkCollection)
     documentClient.createCollection(databaseLink, documentCollection, null)
 
-    // Start the thread to add new documents
-    val insertingThread = new Thread(new Runnable() {
+    /*
+     * SCENARIO 1: STREAM READER TO STREAM WRITER TO SINK COLLECTION
+     *
+     * Start a thread to insert documents to the source collection.
+     * The documents have ID ranging from 1 -> insertIterations.
+     *
+     * In the middle of that process, create a DataFrame from the change feed of the source collection.
+     * After that, create a DataStreamWriter to read the streaming DataFrame to the sink collection.
+     *
+     * When all documents are written, verify that the sink collection has an acceptable number of documents
+     * from the source collection.
+     */
+
+    var docIdIndex = 1
+
+    val insertingRunnable = new Runnable() {
       override def run(): Unit = {
-        (1 to insertIterations).foreach(i => {
+        (docIdIndex until docIdIndex + insertIterations).foreach(i => {
           val newDoc = new Document()
           newDoc.setId(s"$i")
           newDoc.set(cosmosDBDefaults.PartitionKeyName, i)
           newDoc.set("content", s"sample content for document with ID $i")
           documentClient.createDocument(sourceCollectionLink, newDoc, null, true)
+          logInfo(s"Created document with ID $i")
           TimeUnit.MILLISECONDS.sleep(insertIntervalMs)
         })
+        docIdIndex = docIdIndex + insertIterations
       }
-    })
+    }
+
+    // Start the thread to add new documents
+    var insertingThread = new Thread(insertingRunnable)
     insertingThread.start()
 
     val sourceConfigMap = configMap.
       +((CosmosDBConfig.ChangeFeedQueryName, "Structured Stream unit test"))
 
     // Start to read the stream
-    val streamData = spark.readStream
+    var streamData = spark.readStream
       .format(classOf[CosmosDBSourceProvider].getName)
       .options(sourceConfigMap)
       .load()
@@ -608,24 +627,109 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
 
     FileUtils.deleteDirectory(new File(checkpointPath))
 
-    val streamingQuery = streamData.writeStream
+    // Start to write the stream
+    val streamingQueryWriter = streamData.writeStream
+      .format(classOf[CosmosDBSinkProvider].getName)
+      .outputMode("append")
+      .options(sinkConfigMap)
+      .option("checkpointLocation", checkpointPath)
+
+    var streamingQuery = streamingQueryWriter.start()
+
+    TimeUnit.MILLISECONDS.sleep(streamingTimeMs)
+
+    insertingThread.join(streamingGapMs)
+
+    // Verify the documents have streamed to the new collection
+    val df = spark.read.cosmosDB(Config(sinkConfigMap))
+    var streamedIdCheckRangeStart = (streamingGapMs + streamingSinkDelayMs) / insertIntervalMs
+    var streamedIdCheckRangeEnd = streamedIdCheckRangeStart + streamingTimeMs / 2 / insertIntervalMs
+    df.rdd.map(row => row.getString(row.fieldIndex("id")).toInt).collect().sortBy(x => x) should
+      contain allElementsOf (streamedIdCheckRangeStart to streamedIdCheckRangeEnd).toList
+
+    streamingQuery.stop()
+
+    /*
+     * SCENARIO 2: NEW STREAM WRITER
+     *
+     * Similar to scenario 2, except we create a new DataStreamWriter to continue from the previous checkpoints.
+     *
+     * Also start a new thread to insert a batch of documents with ID from insertIterations + 1 -> insertIterations * 2.
+     *
+     * Verify that the sink collection contains the changes spanning from the previous batch to the current batch,
+     * without missing any changes in between.
+      */
+
+    logInfo("Starting scenario of new stream writer")
+
+    // Start to insert more data
+    insertingThread = new Thread(insertingRunnable)
+    insertingThread.start()
+    TimeUnit.MILLISECONDS.sleep(streamingGapMs)
+
+    // Resume writing to the stream
+    streamingQuery = streamData.writeStream
       .format(classOf[CosmosDBSinkProvider].getName)
       .outputMode("append")
       .options(sinkConfigMap)
       .option("checkpointLocation", checkpointPath)
       .start()
 
-    TimeUnit.MILLISECONDS.sleep(streamingTimeMs)
+    // Wait for the inserting thread to complete
+    insertingThread.join()
 
-    insertingThread.join(streamingGapMs)
-
-    streamingQuery.stop()
-
-    // Verify the documents has streamed to the new collection
-    val df = spark.read.cosmosDB(Config(sinkConfigMap))
-    val streamedIdCheckRangeStart = (streamingGapMs + streamingSinkDelayMs) / insertIntervalMs
-    val streamedIdCheckRangeEnd = streamedIdCheckRangeStart + streamingTimeMs / 2 / insertIntervalMs
+    // Verify that the documents have streamed to the new collection
+    streamedIdCheckRangeEnd = streamedIdCheckRangeEnd * 2 - streamingGapMs / insertIntervalMs
     df.rdd.map(row => row.getString(row.fieldIndex("id")).toInt).collect().sortBy(x => x) should
       contain allElementsOf (streamedIdCheckRangeStart to streamedIdCheckRangeEnd).toList
+
+    streamingQuery.stop()
+    CosmosDBRDDIterator.resetCollectionContinuationTokens()
+
+    // to be enabled
+    def scenario3(): Any = {
+
+      /*
+       * SCENARIO 3: NEW STREAM READER AND NEW STREAM WRITER
+       *
+       * Similar to scenario 1, except we create a new StreamReader and a new StreamWriter to simulate node failures.
+       *
+       * Another batch of changes will be written with ID from insertIterations * 2 + 1 -> insertIterations * 3
+       *
+       * Verify that the sink collection receives all changes from the first batch without missing any documents in between.
+        */
+
+      logInfo("Starting scenario of new stream reader and new stream writer")
+
+      // Start to insert more data
+      insertingThread = new Thread(insertingRunnable)
+      insertingThread.start()
+      TimeUnit.MILLISECONDS.sleep(streamingGapMs)
+
+      // Start to read change feed stream again
+      streamData = spark.readStream
+        .format(classOf[CosmosDBSourceProvider].getName)
+        .options(sourceConfigMap)
+        .load()
+
+      // Start to write to the stream again
+      streamingQuery = streamData.writeStream
+        .format(classOf[CosmosDBSinkProvider].getName)
+        .outputMode("append")
+        .options(sinkConfigMap)
+        .option("checkpointLocation", checkpointPath)
+        .start()
+
+      // Wait for the inserting thread to complete
+      insertingThread.join()
+
+      // Verify that the documents have streamed to the new collection
+      streamedIdCheckRangeEnd = streamedIdCheckRangeEnd * 3 - streamingGapMs / insertIntervalMs
+      df.rdd.map(row => row.getString(row.fieldIndex("id")).toInt).collect().sortBy(x => x) should
+        contain allElementsOf (streamedIdCheckRangeStart to streamedIdCheckRangeEnd).toList
+
+      streamingQuery.stop()
+      CosmosDBRDDIterator.resetCollectionContinuationTokens()
+    }
   }
 }

--- a/src/test/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBDataFrameSpec.scala
+++ b/src/test/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBDataFrameSpec.scala
@@ -22,6 +22,7 @@
   */
 package com.microsoft.azure.cosmosdb.spark.schema
 
+import java.io.File
 import java.sql.{Date, Timestamp}
 import java.util.concurrent.TimeUnit
 
@@ -30,6 +31,7 @@ import com.microsoft.azure.cosmosdb.spark.rdd.CosmosDBRDD
 import com.microsoft.azure.cosmosdb.spark.streaming.{CosmosDBSinkProvider, CosmosDBSourceProvider}
 import com.microsoft.azure.cosmosdb.spark.{RequiresCosmosDB, _}
 import com.microsoft.azure.documentdb._
+import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.types.{StructField, _}
 import org.apache.spark.sql.{Row, SaveMode, SparkSession}
@@ -602,11 +604,15 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
       -(CosmosDBConfig.Collection).
       +((CosmosDBConfig.Collection, sinkCollection))
 
+    val checkpointPath = "./checkpoint"
+
+    FileUtils.deleteDirectory(new File(checkpointPath))
+
     val streamingQuery = streamData.writeStream
       .format(classOf[CosmosDBSinkProvider].getName)
       .outputMode("append")
       .options(sinkConfigMap)
-      .option("checkpointLocation", "./checkpoint")
+      .option("checkpointLocation", checkpointPath)
       .start()
 
     TimeUnit.MILLISECONDS.sleep(streamingTimeMs)


### PR DESCRIPTION
Enable support for Structured Stream (preview)

- Added ComsosDBSourceProvider to read Change Feed as Spark stream
- Added ComsosDBSinkProvider to consume Spark stream back to CosmosDB. 
- Added a simple unit test to demonstrate the use case for the two scenarios.
- This changed depends on the few changes in the change to support Change Feed (https://github.com/Azure/azure-cosmosdb-spark/pull/43)
- To be added more tests, validation, and benchmark

cc @shireeshkthota @dennyglee 