### PR TITLE
Improve throughput when writing to CosmosDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,16 @@ limitations under the License.
       <version>1.12.0</version>
     </dependency>
     <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>1.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-documentdb-rx</artifactId>
+      <version>0.9.0-rc1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -54,6 +54,7 @@ object CosmosDBConfig {
   val ChangeFeedQueryName = "changefeedqueryname"
   val ChangeFeedNewQuery = "changefeednewquery"
   val ChangeFeedCheckpointLocation = "changefeedcheckpointlocation"
+  val WritingBatchSize = "writingbatchsize"
 
   // Mandatory
   val required = List(
@@ -76,6 +77,7 @@ object CosmosDBConfig {
   val DefaultChangeFeedNewQuery = false
   val DefaultQueryMaxDegreeOfParallelism = Integer.MAX_VALUE
   val DefaultQueryMaxBufferedItemCount = Integer.MAX_VALUE
+  val DefaultWritingBatchSize = 500
 
   def parseParameters(parameters: Map[String, String]): Map[String, Any] = {
     return parameters.map { case (x, v) => x -> v }

--- a/src/test/scala/com/microsoft/azure/cosmosdb/spark/config/ConfigSpec.scala
+++ b/src/test/scala/com/microsoft/azure/cosmosdb/spark/config/ConfigSpec.scala
@@ -57,6 +57,7 @@ class ConfigSpec extends RequiresCosmosDB {
       CosmosDBRelation.lastSampleSize should equal(CosmosDBConfig.DefaultSampleSize)
 
       CosmosDBSpark.lastUpsertSetting.get should equal(CosmosDBConfig.DefaultUpsert)
+      CosmosDBSpark.lastWritingBatchSize.get should equal(CosmosDBConfig.DefaultWritingBatchSize)
     }
 
   it should "be able to override the defaults" in withSparkSession() { ss =>
@@ -70,6 +71,7 @@ class ConfigSpec extends RequiresCosmosDB {
       "schema_samplingratio" -> "0.5",
       "schema_samplesize" -> "200",
       "query_pagesize" -> "300",
+      "writIngbatchSize" -> "100",
       "query_maxretryattemptsonthrottledrequests" -> "15",
       "query_maxretrywaittimeinseconds" -> "3",
       "query_maxdegreeofparallelism" -> "100",
@@ -84,27 +86,29 @@ class ConfigSpec extends RequiresCosmosDB {
     df.collect()
     df.write.cosmosDB(readConfig)
 
-    CosmosDBConnection.lastConsistencyLevel.get.toString should equal(readConfig.properties("consistencylevel").toString)
+    CosmosDBConnection.lastConsistencyLevel.get.toString should
+      equal(readConfig.properties(CosmosDBConfig.ConsistencyLevel).toString)
 
     val connectionPolicy = CosmosDBConnection.lastConnectionPolicy
-    connectionPolicy.getConnectionMode.toString should equal(readConfig.properties("connectionmode").toString)
+    connectionPolicy.getConnectionMode.toString should equal(readConfig.properties(CosmosDBConfig.ConnectionMode).toString)
     connectionPolicy.getRetryOptions.getMaxRetryAttemptsOnThrottledRequests.toString should
-      equal(readConfig.properties("query_maxretryattemptsonthrottledrequests"))
+      equal(readConfig.properties(CosmosDBConfig.QueryMaxRetryOnThrottled))
     connectionPolicy.getRetryOptions.getMaxRetryWaitTimeInSeconds.toString should
-      equal(readConfig.properties("query_maxretrywaittimeinseconds"))
+      equal(readConfig.properties(CosmosDBConfig.QueryMaxRetryWaitTimeSecs))
     connectionPolicy.getPreferredLocations.size() should equal(2)
 
     val feedOptions = CosmosDBRDDIterator.lastFeedOptions
-    feedOptions.getPageSize.toString should equal(readConfig.properties("query_pagesize"))
-    feedOptions.getMaxDegreeOfParallelism.toString should equal(readConfig.properties("query_maxdegreeofparallelism"))
-    feedOptions.getMaxBufferedItemCount.toString should equal(readConfig.properties("query_maxbuffereditemcount"))
-    feedOptions.getEnableScanInQuery.toString should equal(readConfig.properties("query_enablescan"))
-    feedOptions.getDisableRUPerMinuteUsage.toString should equal(readConfig.properties("query_disableruperminuteusage"))
-    feedOptions.getEmitVerboseTracesInQuery.toString should equal(readConfig.properties("query_emitverbosetraces"))
+    feedOptions.getPageSize.toString should equal(readConfig.properties(CosmosDBConfig.QueryPageSize))
+    feedOptions.getMaxDegreeOfParallelism.toString should equal(readConfig.properties(CosmosDBConfig.QueryMaxDegreeOfParallelism))
+    feedOptions.getMaxBufferedItemCount.toString should equal(readConfig.properties(CosmosDBConfig.QueryMaxBufferedItemCount))
+    feedOptions.getEnableScanInQuery.toString should equal(readConfig.properties(CosmosDBConfig.QueryEnableScan))
+    feedOptions.getDisableRUPerMinuteUsage.toString should equal(readConfig.properties(CosmosDBConfig.QueryDisableRUPerMinuteUsage))
+    feedOptions.getEmitVerboseTracesInQuery.toString should equal(readConfig.properties(CosmosDBConfig.QueryEmitVerboseTraces))
 
-    CosmosDBRelation.lastSamplingRatio.toString should equal(readConfig.properties("schema_samplingratio"))
-    CosmosDBRelation.lastSampleSize.toString should equal(readConfig.properties("schema_samplesize"))
+    CosmosDBRelation.lastSamplingRatio.toString should equal(readConfig.properties(CosmosDBConfig.SamplingRatio))
+    CosmosDBRelation.lastSampleSize.toString should equal(readConfig.properties(CosmosDBConfig.SampleSize))
 
-    CosmosDBSpark.lastUpsertSetting.get.toString should equal(readConfig.properties("upsert"))
+    CosmosDBSpark.lastUpsertSetting.get.toString should equal(readConfig.properties(CosmosDBConfig.Upsert))
+    CosmosDBSpark.lastWritingBatchSize.get.toString should equal(readConfig.properties(CosmosDBConfig.WritingBatchSize))
   }
 }


### PR DESCRIPTION
Improve writing throughput by using CosmosDB Rx Java SDK.
Batch size can be configured through `writingbatchsize` configuration.
In test run with batch size = 500, writing 4.3 million documents took 4.1 minutes on a 4 worker nodes cluster (~17500 documents/sec)

This addresses the issue in https://github.com/Azure/azure-cosmosdb-spark/issues/32

cc @dennyglee @shireeshkthota 