### PR TITLE
Fix schema issue in streaming

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBSchema.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBSchema.scala
@@ -65,6 +65,8 @@ case class CosmosDBSchema[T <: RDD[Document]](
 
     val reduced = flatMap.reduceByKey(compatibleType)
 
+    // Group the field and derive the common type
+    // Sort the property in the schema for predictable order
     val structFields = reduced.aggregate(Seq[StructField]())({
       case (fields, (name, tpe)) =>
         val newType = tpe match {
@@ -72,7 +74,7 @@ case class CosmosDBSchema[T <: RDD[Document]](
           case other => other
         }
         fields :+ StructField(name, newType)
-    }, (oldFields, newFields) => oldFields ++ newFields)
+    }, (oldFields, newFields) => oldFields ++ newFields).sortBy(field => field.name)
 
     StructType(structFields)
   }


### PR DESCRIPTION
When doing transformations with the stream, the column of the data frame may get mixed up (query for one column may yield the result for a different column). 

This is because the data frame schema's properties order is nondeterministic between different times of schema inference.  This change fixes this issue by defining a fixed order for the schema fields. 

Potentially there can still be issues if the schemas are different between the start of the stream reader and start of the stream writer. The right approach is to use one schema for both steps. I will be looking for a straightforward way to do that.

cc @dennyglee @shireeshkthota 