### PR TITLE
Bump to Spark 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure</groupId>
-  <artifactId>azure-cosmosdb-spark_2.1.0_2.11</artifactId>
+  <artifactId>azure-cosmosdb-spark_2.3.1_2.11</artifactId>
   <packaging>jar</packaging>
   <version>1.1.2</version>
   <name>${project.groupId}:${project.artifactId}</name>
@@ -36,7 +36,7 @@ limitations under the License.
     <scala.binary.version>2.11</scala.binary.version>
     <sonar.projectBaseDir>azure-cosmosdb-spark</sonar.projectBaseDir>
     <scala.test.version>3.0.1</scala.test.version>
-    <spark.version>2.1.0</spark.version>
+    <spark.version>2.3.1</spark.version>
     <slf4j.version>1.7.6</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
     <tinkerpop.version>3.2.5</tinkerpop.version>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBSchema.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBSchema.scala
@@ -112,7 +112,7 @@ case class CosmosDBSchema[T <: RDD[Document]](
     * @return Compatible type for both t1 and t2
     */
   private def compatibleType(t1: DataType, t2: DataType): DataType = {
-    TypeCoercion.findTightestCommonTypeOfTwo(t1, t2) match {
+    TypeCoercion.findTightestCommonType(t1, t2) match {
       case Some(commonType) => commonType
 
       case None =>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/InferSchema.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/InferSchema.scala
@@ -123,7 +123,7 @@ object InferSchema {
     * @return the DataType that matches on the input DataTypes
     */
   private def compatibleType(t1: DataType, t2: DataType): DataType = {
-    TypeCoercion.findTightestCommonTypeOfTwo(t1, t2).getOrElse {
+    TypeCoercion.findTightestCommonType(t1, t2).getOrElse {
       // t1 or t2 is a StructType, ArrayType, or an unexpected type.
       (t1, t2) match {
         case (StructType(fields1), StructType(fields2)) =>


### PR DESCRIPTION
findTightestCommonTypeOfTwo has been renamed to findTightestCommonType