### PR TITLE
BulkExecutor + Structured Streaming enhancements for Spark 2.3

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -29,6 +29,8 @@ import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
 import scala.language.implicitConversions
 
+import java.lang.management.ManagementFactory
+
 object CosmosDBConnection {
   // For verification purpose
   var lastConnectionPolicy: ConnectionPolicy = _
@@ -198,7 +200,8 @@ private[spark] case class CosmosDBConnection(config: Config) extends LoggingTrai
   private def getClientConfiguration(config: Config): ClientConfiguration = {
     val connectionPolicy = new ConnectionPolicy()
     connectionPolicy.setConnectionMode(connectionMode)
-    connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix)
+    connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix + " " + ManagementFactory.getRuntimeMXBean().getName())
+
     config.get[String](CosmosDBConfig.ConnectionMaxPoolSize) match {
       case Some(maxPoolSizeStr) => connectionPolicy.setMaxPoolSize(maxPoolSizeStr.toInt)
       case None => // skip

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
@@ -205,7 +205,7 @@ object CosmosDBSpark extends LoggingTrait {
     val updater: DocumentBulkExecutor = connection.getDocumentBulkImporter(collectionThroughput, partitionKeyDefinition)
 
     // Set retry options to 0 to pass control to BulkExecutor
-    connection.setZeroClientRetryPolicy
+    // connection.setZeroClientRetryPolicy
 
     val updateItems = new java.util.ArrayList[UpdateItem](writingBatchSize)
     val updatePatchItems = new java.util.ArrayList[Document](writingBatchSize)
@@ -265,7 +265,7 @@ object CosmosDBSpark extends LoggingTrait {
     val importer: DocumentBulkExecutor = connection.getDocumentBulkImporter(collectionThroughput, partitionKeyDefinition)
 
     // Set retry options to 0 to pass control to BulkExecutor
-    connection.setZeroClientRetryPolicy
+    // connection.setZeroClientRetryPolicy
 
     val documents = new java.util.ArrayList[String](writingBatchSize)
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -70,6 +70,7 @@ object CosmosDBConfig {
   val ChangeFeedQueryName = "changefeedqueryname"
   val ChangeFeedNewQuery = "changefeednewquery"
   val ChangeFeedCheckpointLocation = "changefeedcheckpointlocation"
+  val InferStreamSchema = "inferstreamschema"
 
   // Not a config, constant
   val StreamingTimestampToken = "tsToken"
@@ -149,6 +150,8 @@ object CosmosDBConfig {
   val DefaultAdlMaxFileCount: Int = Int.MaxValue
 
   val SinglePartitionCollectionOfferThroughput = 10000
+
+  val DefaultInferStreamSchema = true
 
   def parseParameters(parameters: Map[String, String]): Map[String, Any] = {
     return parameters.map { case (x, v) => x -> v }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -86,6 +86,7 @@ object CosmosDBConfig {
   val BulkUpdate = "bulkupdate"
   val MaxMiniBatchUpdateCount = "maxminibatchupdatecount"
   val PartitionKeyDefinition = "partitionkeydefinition"
+  val WriteThroughputBudget = "writethroughputbudget"
 
   // Rx Java related write config
   val WritingBatchDelayMs = "writingbatchdelayms"

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -305,8 +305,13 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         .getOrElse(CosmosDBConfig.DefaultStructuredStreaming.toString)
         .toBoolean
 
+      val shouldInferStreamSchema: Boolean = config
+        .get[String](CosmosDBConfig.InferStreamSchema)
+        .getOrElse(CosmosDBConfig.DefaultInferStreamSchema.toString)
+        .toBoolean
+
       // Query for change feed
-      val response = connection.readChangeFeed(changeFeedOptions, structuredStreaming)
+      val response = connection.readChangeFeed(changeFeedOptions, structuredStreaming, shouldInferStreamSchema)
       val iteratorDocument = response._1
       val nextToken = response._2
 


### PR DESCRIPTION
- Allow schema agnostic read from change feed
- Expose write throughput budget 
- Add high bulk executor initialization retry policy + remove gateway mode connection policy override