### PR TITLE
fix #202 to save null value properties as null in CosmosDB

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
@@ -121,8 +121,11 @@ object CosmosDBRowConverter extends RowConverter[Document]
   def rowToJSONObject(row: Row): JSONObject = {
     var jsonObject: JSONObject = new JSONObject()
     row.schema.fields.zipWithIndex.foreach({
-      case (field, i) if row.isNullAt(i) => if (field.dataType == NullType) jsonObject.remove(field.name)
-      case (field, i)                    => jsonObject.put(field.name, convertToJson(row.get(i), field.dataType))
+      case (field, i)                    => {
+        if(row.get(i) == null)  jsonObject.put(field.name, JSONObject.NULL)
+        else if (field.dataType == NullType) jsonObject.remove(field.name)
+        else jsonObject.put(field.name, convertToJson(row.get(i), field.dataType))
+      }
     })
     jsonObject
   }


### PR DESCRIPTION
Currently, if an object has null value properties, these properties gets removed from the object and the json document stored won't have these properties. The change is a fix to have the null properties stored as part of the json document