### PR TITLE
Minor fixes for batch write 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ limitations under the License.
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.5</version>
+            <version>2.9.5</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
@@ -415,16 +415,14 @@ object CosmosDBSpark extends LoggingTrait {
     val upsert: Boolean = config
       .getOrElse(CosmosDBConfig.Upsert, String.valueOf(CosmosDBConfig.DefaultUpsert))
       .toBoolean
-    var writingBatchSize: Int = 0
-    if (isBulkImporting) {
-      val writingBatchSize = config
-        .getOrElse(CosmosDBConfig.WritingBatchSize, String.valueOf(CosmosDBConfig.DefaultWritingBatchSize_BulkInsert))
+    val writingBatchSize = if (isBulkImporting) {
+      config.getOrElse(CosmosDBConfig.WritingBatchSize, String.valueOf(CosmosDBConfig.DefaultWritingBatchSize_BulkInsert))
         .toInt
     } else {
-      val writingBatchSize = config
-        .getOrElse(CosmosDBConfig.WritingBatchSize, String.valueOf(CosmosDBConfig.DefaultWritingBatchSize_PointInsert))
+      config.getOrElse(CosmosDBConfig.WritingBatchSize, String.valueOf(CosmosDBConfig.DefaultWritingBatchSize_PointInsert))
         .toInt
     }
+
     val writingBatchDelayMs = config
       .getOrElse(CosmosDBConfig.WritingBatchDelayMs, String.valueOf(CosmosDBConfig.DefaultWritingBatchDelayMs))
       .toInt


### PR DESCRIPTION
- bump up jackson-core version to be in parity with java sdk 
- fix write batch size config parsing

