### PR TITLE
Fix client creation to create only one client per executor 

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -158,6 +158,8 @@ object CosmosDBConfig {
 
   val DefaultInferStreamSchema = true
 
+  val DefaultMaxConnectionPoolSize = 500
+
   def parseParameters(parameters: Map[String, String]): Map[String, Any] = {
     return parameters.map { case (x, v) => x -> v }
   }


### PR DESCRIPTION
The change fixes the issue of creating a client instance per process and that was causing port exhaustion issue on spark machines. This changes it to be one client per process and also change the default pool size to 500 to be able to use the client efficiently 