### PR TITLE
Solved problems with unsafe data structures (InternalRow and UnsafeAr…

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
@@ -125,6 +125,7 @@ object CosmosDBRowConverter extends RowConverter[Document]
   private def rowTyperouterToJsonArray(element: Any, schema: StructType) = element match {
     case e: Row => rowToJSONObject(e)
     case e: InternalRow => internalRowToJSONObject(e, schema)
+    case _ => throw new Exception(s"Cannot cast $element into a Json value. Struct $element has no matching Json value.")
   }
 
   def rowToJSONObject(row: Row): JSONObject = {
@@ -189,6 +190,7 @@ object CosmosDBRowConverter extends RowConverter[Document]
     data match {
       case d:Seq[_] => arrayTypeToJSONArray(elementType, d, isInternalRow)
       case d:ArrayData => arrayDataTypeToJSONArray(elementType,d, isInternalRow)
+      case _ => throw new Exception(s"Cannot cast $data into a Json value. ArrayType $elementType has no matching Json value.")
     }
   }
 


### PR DESCRIPTION
This pull request solves the problem that appears mainly in structured streaming with conversions of unsafe types (InternalRow and UnsafeArrayData). Example #255 
This PR has been tested in the following complex structure:

root
 |-- _attachments: string (nullable = true)
 |-- _date: string (nullable = true)
 |-- _etag: string (nullable = true)
 |-- _msgCls: string (nullable = true)
 |-- _numMsg: string (nullable = true)
 |-- _pagId: string (nullable = true)
 |-- _rid: string (nullable = true)
 |-- _self: string (nullable = true)
 |-- _ts: integer (nullable = true)
 |-- _type: string (nullable = true)
 |-- _ver: string (nullable = true)
 |-- aggrpId: string (nullable = true)
 |-- destPostalOff: string (nullable = true)
 |-- elements: array (nullable = true)
 |    |-- element: struct (containsNull = false)
 |    |    |-- code: string (nullable = true)
 |    |    |-- type: string (nullable = true)
 |-- event: struct (nullable = true)
 |    |-- elements: integer (nullable = true)
 |    |-- genPoint: string (nullable = true)
 |    |-- destCountry3: string (nullable = true)
 |    |-- aggrpType: string (nullable = true)
 |    |-- code: string (nullable = true)
 |    |-- turn: string (nullable = true)
 |    |-- app: string (nullable = true)
 |    |-- reportNode: string (nullable = true)
 |    |-- destCountry: string (nullable = true)
 |-- id: string (nullable = true)
 |-- inter: string (nullable = true)

It contains not only nested structures but also arrays of structures.