### PR TITLE
Fix unusable method if DataFrame wanted instead of DataFrameStreaming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.4.3-SNAPSHOT</version>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/DataFrameReaderFunctions.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/DataFrameReaderFunctions.scala
@@ -64,7 +64,7 @@ private[spark] case class DataFrameReaderFunctions(@transient dfr: DataFrameRead
     * @return DataFrame
     */
   def cosmosDB[T <: Product : TypeTag](readConfig: Config): DataFrame =
-    createCosmosDBDataFrame(InferSchema.reflectSchema[T](), Some(readConfig), None)
+    createCosmosDBDataFrame(InferSchema.reflectSchema[T](), Option(readConfig), None)
 
   /**
     * Creates a [[DataFrame]] with the set schema
@@ -72,7 +72,7 @@ private[spark] case class DataFrameReaderFunctions(@transient dfr: DataFrameRead
     * @param schema the schema definition
     * @return DataFrame
     */
-  def cosmosDB(schema: StructType): DataFrame = createCosmosDBDataFrame(Some(schema), None, None)
+  def cosmosDB(schema: StructType): DataFrame = createCosmosDBDataFrame(Option(schema), None, None)
 
   /**
     * Creates a [[DataFrame]] with the set schema
@@ -81,7 +81,7 @@ private[spark] case class DataFrameReaderFunctions(@transient dfr: DataFrameRead
     * @param readConfig any custom read configuration
     * @return DataFrame
     */
-  def cosmosDB(schema: StructType, readConfig: Config, sqlContext: SQLContext): DataFrame = createCosmosDBDataFrame(Some(schema), Some(readConfig), Some(sqlContext))
+  def cosmosDB(schema: StructType, readConfig: Config, sqlContext: SQLContext): DataFrame = createCosmosDBDataFrame(Option(schema), Option(readConfig), Option(sqlContext))
 
   private def createDataFrame(schema: Option[StructType], readConfig: Option[Config], sqlContext: Option[SQLContext]): DataFrame = {
     var cachingMode: CachingMode = CachingMode.NONE
@@ -135,12 +135,12 @@ private[spark] case class DataFrameReaderFunctions(@transient dfr: DataFrameRead
           .-(CosmosDBConfig.RollingChangeFeed)
           .-(CosmosDBConfig.CachingModeParam)
           .+((CosmosDBConfig.CachingModeParam, CachingMode.CACHE.toString)))
-        val df = createDataFrame(schema, Some(dfConfig), sqlContext)
+        val df = createDataFrame(schema, Option(dfConfig), sqlContext)
 
         val changeFeedConfig = Config(dfConfig.asOptions
           .+((CosmosDBConfig.ReadChangeFeed, "true"))
           .-(CosmosDBConfig.CachingModeParam))
-        val changeFeedDf = createDataFrame(schema, Some(changeFeedConfig), sqlContext)
+        val changeFeedDf = createDataFrame(schema, Option(changeFeedConfig), sqlContext)
 
         df.union(changeFeedDf)
       } else {


### PR DESCRIPTION
In DataFrameReaderFunctions there is an [unusable method](https://github.com/Azure/azure-cosmosdb-spark/blob/4de6a15edcb80fd96f4bb802fdaa5f7efb59ae14/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/DataFrameReaderFunctions.scala#L84) method if DataFrame is wanted instead of Streaming DataFrame with this signature: `def cosmosDB(schema: StructType, readConfig: Config, sqlContext: SQLContext): DataFrame`

This calls a private method that should receive an `Option[SQLContext]` argument, but it's not possible when using `Some(null)`, because this will create a `Some[Null]` type value. To fix this, `Option(sqlContext)` is used instead of `Some(sqlContext)` in order to pass a `None` value. Other Optionals are changed too.

This PR should be cherry-picked to 2.3 branch. Branches 2.2 and 2.1 are not affected.