### PR TITLE
Charanjit/streamingbugfix

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -23,7 +23,9 @@
 package com.microsoft.azure.cosmosdb.spark
 
 import java.lang.management.ManagementFactory
+
 import com.microsoft.azure.cosmosdb.spark.config._
+import com.microsoft.azure.documentdb
 import com.microsoft.azure.documentdb._
 import com.microsoft.azure.documentdb.bulkexecutor.DocumentBulkExecutor
 import com.microsoft.azure.documentdb.internal._
@@ -62,10 +64,16 @@ object CosmosDBConnection extends CosmosDBLoggingTrait {
       }
       else {
         val collectionSelfLink = getCollectionSelfLink(clientConfiguration)
-        val permission = new Permission()
-        permission.set("_token", clientConfiguration.key)
-        permission.setResourceLink(collectionSelfLink)
-        val permissions = List(permission)
+        val permissionWithSelfLink = new Permission()
+        permissionWithSelfLink.set("_token", clientConfiguration.key)
+        permissionWithSelfLink.setResourceLink(collectionSelfLink)
+
+        val permissionWithNamedResourceLink = new Permission()
+        permissionWithNamedResourceLink.set("_token", clientConfiguration.key)
+        permissionWithNamedResourceLink.setResourceLink(clientConfiguration.resourceLink)
+
+        val permissions = List(permissionWithSelfLink, permissionWithNamedResourceLink)
+
         clients(cacheKey) = new DocumentClient(
           clientConfiguration.host,
           permissions,


### PR DESCRIPTION
Addressed a bug in resource token feature. The spark connector now fully supports client initialization with the resource token