### PR TITLE
Upgrade scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
+    <artifactId>azure-cosmosdb-spark_2.4.0_2.12</artifactId>
     <packaging>jar</packaging>
     <version>3.0.6</version>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -32,8 +32,8 @@ limitations under the License.
         </license>
     </licenses>
     <properties>
-        <scala.version>2.11.12</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <scala.version>2.12.11</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <sonar.projectBaseDir>azure-cosmosdb-spark</sonar.projectBaseDir>
         <scala.test.version>3.1.1</scala.test.version>
         <spark.version>2.4.4</spark.version>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDD.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDD.scala
@@ -115,10 +115,11 @@ class CosmosDBRDD(
       case cosmosDBPartition: CosmosDBPartition =>
         logInfo(s"CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id ${cosmosDBPartition.partitionKeyRangeId}")
 
-        val taskCompletionListener:TaskCompletionListener = (ctx: TaskContext) => {
-          logInfo(s"CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id ${cosmosDBPartition.partitionKeyRangeId}")
+        val completionListener: TaskCompletionListener = new TaskCompletionListener() {
+          override def onTaskCompletion(context: TaskContext): Unit =
+            logInfo(s"CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id ${cosmosDBPartition.partitionKeyRangeId}")
         }
-        context.addTaskCompletionListener(taskCompletionListener)
+        context.addTaskCompletionListener(completionListener)
 
         new CosmosDBRDDIterator(
           hadoopConfig,

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDD.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDD.scala
@@ -31,6 +31,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.util.TaskCompletionListener
 import org.apache.spark.{Partition, TaskContext}
 
 import scala.collection.mutable
@@ -114,9 +115,10 @@ class CosmosDBRDD(
       case cosmosDBPartition: CosmosDBPartition =>
         logInfo(s"CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id ${cosmosDBPartition.partitionKeyRangeId}")
 
-        context.addTaskCompletionListener((ctx: TaskContext) => {
+        val taskCompletionListener:TaskCompletionListener = (ctx: TaskContext) => {
           logInfo(s"CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id ${cosmosDBPartition.partitionKeyRangeId}")
-        })
+        }
+        context.addTaskCompletionListener(taskCompletionListener)
 
         new CosmosDBRDDIterator(
           hadoopConfig,

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -41,6 +41,7 @@ import com.microsoft.azure.documentdb.internal.HttpConstants.SubStatusCodes
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark._
 import org.apache.spark.sql.sources.Filter
+import org.apache.spark.util.TaskCompletionListener
 
 import scala.collection.mutable
 
@@ -424,9 +425,10 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
     })
 
     // Register an on-task-completion callback to close the input stream.
-    taskContext.addTaskCompletionListener((_: TaskContext) => {
-      closeIfNeeded()
-    })
+    val taskCompletionListener: TaskCompletionListener = new TaskCompletionListener() {
+      override def onTaskCompletion(context: TaskContext): Unit = closeIfNeeded()
+    }
+    taskContext.addTaskCompletionListener(taskCompletionListener)
 
     if (!readingChangeFeed) {
       queryDocuments

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -425,10 +425,13 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
     })
 
     // Register an on-task-completion callback to close the input stream.
-    val taskCompletionListener: TaskCompletionListener = new TaskCompletionListener() {
-      override def onTaskCompletion(context: TaskContext): Unit = closeIfNeeded()
+    val taskCompletionListerner = new TaskCompletionListener() {
+      override def onTaskCompletion(context: TaskContext): Unit = {
+        closeIfNeeded()
+      }
     }
-    taskContext.addTaskCompletionListener(taskCompletionListener)
+
+    taskContext.addTaskCompletionListener(taskCompletionListerner)
 
     if (!readingChangeFeed) {
       queryDocuments


### PR DESCRIPTION
This PR upgrades the build and the code to compile to Scala 2.12.
The code needed minor changes to disambiguate the SAM type inference.

I hope somebody could help out to support a multi-target build to produce 2.11 (if still needed) and 2.12.

Addresses #321 (but it doesn't preserve support for 2.11)