### PR TITLE
Fixing regression introduced in 1.5

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -391,6 +391,11 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
       Tuple2.apply(cfDocuments.iterator(), nextContinuation)
     } else 
     {
+      // next Continuation Token is plain and simple when not using Streaming because
+      // all records will be processed. The parameter 'maxPagesPerBatch' is irrelevant
+      // in this case - so there doesn't need to be any suffix in the continutaion token returned
+      nextContinuation = feedResponse.getResponseContinuation()
+      logDebug(s"<-- readChangeFeed, Non-Streaming, NextContinuation: ${nextContinuation}")
       Tuple2.apply(feedResponse.getQueryIterator, nextContinuation)
     }
   }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -366,7 +366,6 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
           updateTokens(currentToken, nextToken, partitionId)
 
           logDebug(s"changeFeedOptions.partitionKeyRangeId = ${changeFeedOptions.getPartitionKeyRangeId}, continuation = $currentToken, new token = ${response._2}, iterator.hasNext = ${response._1.hasNext}")
-          System.out.println(s"changeFeedOptions.partitionKeyRangeId = ${changeFeedOptions.getPartitionKeyRangeId}, continuation = $currentToken, new token = ${response._2}, iterator.hasNext = ${response._1.hasNext}")
         }
         catch {
           case docex: DocumentClientException => handleGoneException(connection, docex)

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -366,6 +366,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
           updateTokens(currentToken, nextToken, partitionId)
 
           logDebug(s"changeFeedOptions.partitionKeyRangeId = ${changeFeedOptions.getPartitionKeyRangeId}, continuation = $currentToken, new token = ${response._2}, iterator.hasNext = ${response._1.hasNext}")
+          System.out.println(s"changeFeedOptions.partitionKeyRangeId = ${changeFeedOptions.getPartitionKeyRangeId}, continuation = $currentToken, new token = ${response._2}, iterator.hasNext = ${response._1.hasNext}")
         }
         catch {
           case docex: DocumentClientException => handleGoneException(connection, docex)


### PR DESCRIPTION
Fixing a regression that was introduced in 1.5. When reading the change-feed in non-streaming mode the continuation token was incorrectly returned.