### PR TITLE
updated the bulkexecutor version in pom to 2.7.0, which has the merge…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.5.0</version>
+            <version>2.7.0</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>


### PR DESCRIPTION
…all fix for bulkupdate when the pkey = id.