### PR TITLE
Added the config for MaxMiniBatchImportSize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-1.5.0"
+  val currentVersion = "2.4.0_2.11-2.0.0"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -141,7 +141,7 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
   private var documentClient: DocumentClient = CosmosDBConnection.getClient(connectionMode, getClientConfiguration(config))
 
 
-  def getDocumentBulkImporter(collectionThroughput: Int, partitionKeyDefinition: Option[String]): DocumentBulkExecutor = {
+  def getDocumentBulkImporter(collectionThroughput: Int, partitionKeyDefinition: Option[String], maxMiniBatchUpdateCount: Int, maxMiniBatchImportSizeKB: Int): DocumentBulkExecutor = {
     if (bulkImporter == null) {
       val initializationRetryOptions = new RetryOptions()
       initializationRetryOptions.setMaxRetryAttemptsOnThrottledRequests(1000)
@@ -158,7 +158,9 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
           collectionName,
           pkDefinition,
           collectionThroughput
-        ).withInitializationRetryOptions(initializationRetryOptions).build()
+        ).withInitializationRetryOptions(initializationRetryOptions)
+          .withMaxUpdateMiniBatchCount(maxMiniBatchUpdateCount)
+          .withMaxMiniBatchSize(maxMiniBatchImportSizeKB * 1024).build()
       }
       else {
         bulkImporter = DocumentBulkExecutor.builder.from(documentClient,
@@ -166,7 +168,9 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
           collectionName,
           getCollection.getPartitionKey,
           collectionThroughput
-        ).withInitializationRetryOptions(initializationRetryOptions).build()
+        ).withInitializationRetryOptions(initializationRetryOptions)
+          .withMaxUpdateMiniBatchCount(maxMiniBatchUpdateCount)
+          .withMaxMiniBatchSize(maxMiniBatchImportSizeKB * 1024).build()
       }
     }
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -96,6 +96,7 @@ object CosmosDBConfig {
   val PartitionKeyDefinition = "partitionkeydefinition"
   val WriteThroughputBudget = "writethroughputbudget"
   val BulkImportMaxConcurrencyPerPartitionRange = "bulkimport_maxconcurrencyperpartitionrange"
+  val MaxMiniBatchImportSizeKB = "maxminibatchimportsizekb"
 
   // Rx Java related write config
   val WritingBatchDelayMs = "writingbatchdelayms"
@@ -170,6 +171,10 @@ object CosmosDBConfig {
   val DefaultInferStreamSchema = true
 
   val DefaultMaxConnectionPoolSize = 500
+
+  val DefaultMaxMiniBatchImportSizeKB = 100
+
+  val DefaultBulkImportMaxConcurrencyPerPartitionRange = 1
 
   def parseParameters(parameters: Map[String, String]): Map[String, Any] = {
     return parameters.map { case (x, v) => x -> v }


### PR DESCRIPTION
The MaxMiniBatchImportSize was originally set to 200 KB in java async sdk. It was observed that the fixed value causes throttling and retry, especially when the available RU is lesser and increasing the latency. 

Added the config for MaxMiniBatchImportSize so that it can be configured in spark connector as per the RU availability, set the default to 100 KB and set the default BulkImportMaxConcurrencyPerPartitionRange to 1. 

In the experiments performed with the MaxMiniBatchImportSize configured as per available RUs and with the BulkImportMaxConcurrencyPerPartitionRange set to 1, this has consistently improved the ingestion perf upto 25%. 