### PR TITLE
bumped up the bulkexecutor version to 2.9.2 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>
@@ -72,7 +72,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.9.1</version>
+            <version>2.9.2</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-2.0.1"
+  val currentVersion = "2.4.0_2.11-2.0.2"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }


### PR DESCRIPTION
BulkExecutor v2.9.1 had a minor bug becuase of which any fields in the patch doc which is placed after the id & pkey were not getting updated. This has been fixed in v2.9.2. 
