### PR TITLE
Changes to capture bulkUpdate and bulkImport failures + Nested array variable element schema fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-2.0.2"
+  val currentVersion = "2.4.0_2.11-2.0.3"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBSchema.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBSchema.scala
@@ -82,8 +82,7 @@ case class CosmosDBSchema[T <: RDD[Document]](
 
   private def convertToStruct(dataType: Any): DataType = dataType match {
     case array: util.ArrayList[_] =>
-      val arrayType: immutable.Seq[DataType] = array.asScala.toList.map(x => convertToStruct(x)).distinct
-      ArrayType(if (arrayType.nonEmpty) arrayType.head else NullType, arrayType.contains(NullType))
+      typeOfArray(array.asScala.toSeq)
     case hm: util.HashMap[_, _] =>
       val fields = hm.asInstanceOf[util.HashMap[String, AnyRef]].asScala.toMap.map {
         case (k, v) => StructField(k, convertToStruct(v))


### PR DESCRIPTION
1. The BulkUpdate and BulkImport failures were currently being suppressed in the Spark connector because the current check was based on "getErrors" of the BulkExecutor Response. Added the check for "getFailedUpdates" and made the change to throw the exception with (id, pk) tuples of the docs for the failed minibatches.

2. Change to infer the accurate json schema of a nested array based on all elements rather than only the first element.

eg: In the cases like the below doc, wherein the field "trend" has different schema within the same document, the first field was used to infer the schema. This was causing the second field to be read as null causing a failure. Made the change to infer the schema based on the schema of all elements, enabling the accurate read of the second element's value. 

{
    "numberOfEmployees": [
        {
            "trend": []
        },
        {
            "trend": [
                {
                    "growthRate": 100
                }
            ]
        }
    ]
}