### PR TITLE
Spark Connector V2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.9.3</version>
+            <version>2.10.0</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.3</version>
+    <version>2.1.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>
@@ -57,22 +57,22 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-documentdb</artifactId>
-            <version>2.4.1</version>
+            <version>2.4.7</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex</groupId>
             <artifactId>rxjava</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.8</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-cosmosdb</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.6</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.3</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>

--- a/src/main/java/com/microsoft/azure/cosmosdb/spark/ContinuationTokenTrackingIterator.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/spark/ContinuationTokenTrackingIterator.java
@@ -1,0 +1,72 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.spark;
+
+import com.microsoft.azure.documentdb.Resource;
+import com.microsoft.azure.documentdb.FeedResponse;
+import java.util.Iterator;
+
+public final class ContinuationTokenTrackingIterator<T extends Resource> implements Iterator<T> {
+    private String currentContinuationToken;
+    private final FeedResponse<T> feedResponse;
+    private final Iterator<T> inner;
+    private final scala.Function3<String, String, String, scala.Unit> updateBookmarkFunc;
+    private final scala.Function1<String, scala.Unit> loggingAction;
+    private final String partitionId;
+
+    public ContinuationTokenTrackingIterator(
+        final FeedResponse<T> feedResponse,
+        final scala.Function3<String, String, String, scala.Unit> updateBookmarkFunc,
+        final scala.Function1<String, scala.Unit> loggingAction,
+        final String partitionId) {
+        this.feedResponse  = feedResponse;
+        this.inner = feedResponse.getQueryIterator();
+        this.updateBookmarkFunc = updateBookmarkFunc;
+        this.partitionId = partitionId;
+        this.loggingAction = loggingAction;
+    }
+
+	public boolean hasNext() {
+		return this.inner.hasNext();
+	}
+
+	public T next() {
+        T returnValue = this.inner.next();
+        String nextContinuationToken = this.feedResponse.getResponseContinuation();
+
+        if (nextContinuationToken != null &&
+            !nextContinuationToken.equals(this.currentContinuationToken))
+        {
+            this.updateBookmarkFunc.apply(this.currentContinuationToken, nextContinuationToken, this.partitionId);
+            this.loggingAction.apply(
+                String.format(
+                    "Tracking progress... partitionId = '%s', continuation = '%s', new token = '%s'",
+                    this.partitionId,
+                    this.currentContinuationToken,
+                    nextContinuationToken));
+            this.currentContinuationToken = nextContinuationToken;
+        }
+        
+        return returnValue;
+	}
+}

--- a/src/main/java/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicyUtil.java
+++ b/src/main/java/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicyUtil.java
@@ -1,0 +1,75 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.microsoft.azure.cosmosdb.spark.streaming;
+
+import com.microsoft.azure.cosmosdb.Document;
+import com.microsoft.azure.cosmosdb.RequestOptions;
+import com.microsoft.azure.cosmosdb.ResourceResponse;
+import rx.Observable;
+import java.time.Instant;
+import java.time.temporal.ChronoField;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.TimeUnit;
+import scala.util.Random;
+
+public final class CosmosDBWriteStreamRetryPolicyUtil {
+    public static Observable<ResourceResponse<Document>> ProcessWithRetries(
+        final Document document,
+        final RequestOptions requestOptions,
+        final scala.Function2<Document, RequestOptions, Observable<ResourceResponse<Document>>> task,
+        final scala.Function1<Throwable, Boolean> isTransientFunc,
+        final scala.Function1<String, ?> loggingAction,
+        final scala.Function2<Throwable, Document, ?> onPoisonMessageAction,
+        final Random rnd,
+        final int maxRetries,
+        final int maxRetryDelayInMs,
+        final int retryUntil,
+        final AtomicLong attempts)
+    {
+        return task.apply(document, requestOptions)
+            .retryWhen(errors -> errors.<Long>flatMap(t -> {
+                Long attempt = attempts.incrementAndGet();
+                Boolean isTransient = isTransientFunc.apply(t);
+                Integer now = Instant.now().get(ChronoField.MILLI_OF_SECOND);
+                Long delay = (long)rnd.nextInt(maxRetryDelayInMs);
+
+                loggingAction.apply("PROCESSWITHRETRIES attempt: " + attempt.toString() + ", isTransient: " + isTransient.toString() + ", Now: " + now.toString() + ", Delay: " + delay.toString());
+
+                if (isTransient && 
+                    attempt < maxRetries &&
+                    now < retryUntil)
+                {
+                    return Observable.timer(delay, TimeUnit.MILLISECONDS);
+                }
+                else
+                {
+                    return Observable.<Long>error(t);
+                }
+            }))
+            .onErrorResumeNext((t) -> {
+                // add default handler to config
+                onPoisonMessageAction.apply(t, document);
+                return Observable.<ResourceResponse<Document>>empty();
+            });
+    }
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/AsyncCosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/AsyncCosmosDBConnection.scala
@@ -186,13 +186,13 @@ case class AsyncCosmosDBConnection(config: Config) extends CosmosDBLoggingTrait 
 
   def upsertDocument(document: Document,
                      requestOptions: RequestOptions): Observable[ResourceResponse[Document]] = {
-    logDebug(s"Upserting document $document")
+    logTrace(s"Upserting document $document")
     asyncDocumentClient.upsertDocument(collectionLink, document, requestOptions, false)
   }
 
   def createDocument(document: Document,
                      requestOptions: RequestOptions): Observable[ResourceResponse[Document]] = {
-    logDebug(s"Creating document $document")
+    logTrace(s"Creating document $document")
     asyncDocumentClient.createDocument(collectionLink, document, requestOptions, false)
   }
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/AsyncCosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/AsyncCosmosDBConnection.scala
@@ -31,11 +31,14 @@ import com.microsoft.azure.cosmosdb._
 import com.microsoft.azure.cosmosdb.internal._
 import com.microsoft.azure.cosmosdb.rx.AsyncDocumentClient
 import com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter
+import com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBWriteStreamRetryPolicy
 import org.apache.spark.sql.Row
 
 import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
+
+import java.util.concurrent.ConcurrentHashMap
 
 case class AsyncClientConfiguration(host: String,
                                key: String,
@@ -43,26 +46,92 @@ case class AsyncClientConfiguration(host: String,
                                consistencyLevel: ConsistencyLevel)
 
 object AsyncCosmosDBConnection {
-  var client: AsyncDocumentClient = _
-  def getClient(clientConfig: AsyncClientConfiguration): AsyncDocumentClient = synchronized {
-    if (client == null) {
-      client = new AsyncDocumentClient
-      .Builder()
-        .withServiceEndpoint(clientConfig.host)
-        .withMasterKeyOrResourceToken(clientConfig.key)
-        .withConnectionPolicy(clientConfig.connectionPolicy)
-        .withConsistencyLevel(clientConfig.consistencyLevel)
-        .build
+  private lazy val clients: ConcurrentHashMap[Config, AsyncDocumentClient] = {
+    new ConcurrentHashMap[Config, AsyncDocumentClient]
+  }
+
+  val factoryMethod = new java.util.function.Function[Config, AsyncDocumentClient]() {
+      override def apply(c: Config): AsyncDocumentClient = createClient(c)
     }
 
-    client
+  def getClientConfiguration(config: Config): AsyncClientConfiguration = {
+    // Generate connection policy
+    val connectionPolicy = new ConnectionPolicy()
+    val mode = config.get[String](CosmosDBConfig.ConnectionMode).get
+    var connectionMode: ConnectionMode = ConnectionMode.Direct
+    if("gateway".equalsIgnoreCase(mode)) {
+      connectionMode = ConnectionMode.Gateway
+    }
+
+    connectionPolicy.setConnectionMode(connectionMode)
+
+    val applicationName = config.get[String](CosmosDBConfig.ApplicationName)
+    if (applicationName.isDefined) {
+      // Merging the Spark connector version with Spark executor process id and application name for user agent
+      connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix + " " + ManagementFactory.getRuntimeMXBean().getName() + " " + applicationName.get)
+    } else {
+      // Merging the Spark connector version with Spark executor process id for user agent
+      connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix + " " + ManagementFactory.getRuntimeMXBean().getName())
+    }
+
+    config.get[String](CosmosDBConfig.ConnectionRequestTimeout) match {
+      case Some(connectionRequestTimeoutStr) => connectionPolicy.setRequestTimeoutInMillis(connectionRequestTimeoutStr.toInt * 1000)
+      case None => // skip
+    }
+
+    config.get[String](CosmosDBConfig.ConnectionIdleTimeout) match {
+      case Some(connectionIdleTimeoutStr) => connectionPolicy.setIdleConnectionTimeoutInMillis(connectionIdleTimeoutStr.toInt)
+      case None => // skip
+    }
+
+    val maxConnectionPoolSize = config.getOrElse[String](CosmosDBConfig.ConnectionMaxPoolSize, CosmosDBConfig.DefaultMaxConnectionPoolSize.toString)
+    connectionPolicy.setMaxPoolSize(maxConnectionPoolSize.toInt)
+
+    val maxRetryAttemptsOnThrottled = config.getOrElse[String](CosmosDBConfig.QueryMaxRetryOnThrottled, CosmosDBConfig.DefaultQueryMaxRetryOnThrottled.toString)
+    connectionPolicy.getRetryOptions.setMaxRetryAttemptsOnThrottledRequests(maxRetryAttemptsOnThrottled.toInt)
+
+    val maxRetryWaitTimeSecs = config.getOrElse[String](CosmosDBConfig.QueryMaxRetryWaitTimeSecs, CosmosDBConfig.DefaultQueryMaxRetryWaitTimeSecs.toString)
+    connectionPolicy.getRetryOptions.setMaxRetryWaitTimeInSeconds(maxRetryWaitTimeSecs.toInt)
+
+    val preferredRegionList = config.get[String](CosmosDBConfig.PreferredRegionsList)
+    if (preferredRegionList.isDefined) {
+      val preferredLocations = preferredRegionList.get.split(";").toSeq.map(_.trim)
+      connectionPolicy.setPreferredLocations(preferredLocations)
+    }
+
+    // Generate consistency level
+    val consistencyLevel = ConsistencyLevel.valueOf(config.get[String](CosmosDBConfig.ConsistencyLevel)
+      .getOrElse(CosmosDBConfig.DefaultConsistencyLevel))
+
+    AsyncClientConfiguration(
+      config.get[String](CosmosDBConfig.Endpoint).get,
+      config.get[String](CosmosDBConfig.Masterkey).get,
+      connectionPolicy,
+      consistencyLevel
+    )
+  }
+
+  def getClient(config: Config): AsyncDocumentClient = {
+    AsyncCosmosDBConnection.clients.computeIfAbsent(config, AsyncCosmosDBConnection.factoryMethod)
+  }
+
+  def createClient(config: Config) : AsyncDocumentClient = {
+    val clientConfig = getClientConfiguration(config)
+
+    new AsyncDocumentClient
+      .Builder()
+          .withServiceEndpoint(clientConfig.host)
+          .withMasterKeyOrResourceToken(clientConfig.key)
+          .withConnectionPolicy(clientConfig.connectionPolicy)
+          .withConsistencyLevel(clientConfig.consistencyLevel)
+          .build()
   }
 }
 
 case class AsyncCosmosDBConnection(config: Config) extends CosmosDBLoggingTrait with Serializable {
 
   private lazy val asyncDocumentClient: AsyncDocumentClient = {
-    AsyncCosmosDBConnection.getClient(getClientConfiguration(config))
+    AsyncCosmosDBConnection.getClient(config)
   }
 
   private val databaseName = config.get[String](CosmosDBConfig.Database).get
@@ -117,68 +186,15 @@ case class AsyncCosmosDBConnection(config: Config) extends CosmosDBLoggingTrait 
 
   def upsertDocument(document: Document,
                      requestOptions: RequestOptions): Observable[ResourceResponse[Document]] = {
-    logTrace(s"Upserting document $document")
+    logDebug(s"Upserting document $document")
     asyncDocumentClient.upsertDocument(collectionLink, document, requestOptions, false)
   }
 
   def createDocument(document: Document,
                      requestOptions: RequestOptions): Observable[ResourceResponse[Document]] = {
-    logTrace(s"Creating document $document")
+    logDebug(s"Creating document $document")
     asyncDocumentClient.createDocument(collectionLink, document, requestOptions, false)
   }
 
-  private def getClientConfiguration(config: Config): AsyncClientConfiguration = {
-    // Generate connection policy
-    val connectionPolicy = new ConnectionPolicy()
-    val mode = config.get[String](CosmosDBConfig.ConnectionMode).get
-    if("gateway".equalsIgnoreCase(mode)) connectionMode = ConnectionMode.Gateway
-
-    connectionPolicy.setConnectionMode(connectionMode)
-
-    val applicationName = config.get[String](CosmosDBConfig.ApplicationName)
-    if (applicationName.isDefined) {
-      // Merging the Spark connector version with Spark executor process id and application name for user agent
-      connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix + " " + ManagementFactory.getRuntimeMXBean().getName() + " " + applicationName.get)
-    } else {
-      // Merging the Spark connector version with Spark executor process id for user agent
-      connectionPolicy.setUserAgentSuffix(Constants.userAgentSuffix + " " + ManagementFactory.getRuntimeMXBean().getName())
-    }
-
-    config.get[String](CosmosDBConfig.ConnectionRequestTimeout) match {
-      case Some(connectionRequestTimeoutStr) => connectionPolicy.setRequestTimeoutInMillis(connectionRequestTimeoutStr.toInt * 1000)
-      case None => // skip
-    }
-
-    config.get[String](CosmosDBConfig.ConnectionIdleTimeout) match {
-      case Some(connectionIdleTimeoutStr) => connectionPolicy.setIdleConnectionTimeoutInMillis(connectionIdleTimeoutStr.toInt)
-      case None => // skip
-    }
-
-    val maxConnectionPoolSize = config.getOrElse[String](CosmosDBConfig.ConnectionMaxPoolSize, CosmosDBConfig.DefaultMaxConnectionPoolSize.toString)
-    connectionPolicy.setMaxPoolSize(maxConnectionPoolSize.toInt)
-
-    val maxRetryAttemptsOnThrottled = config.getOrElse[String](CosmosDBConfig.QueryMaxRetryOnThrottled, CosmosDBConfig.DefaultQueryMaxRetryOnThrottled.toString)
-    connectionPolicy.getRetryOptions.setMaxRetryAttemptsOnThrottledRequests(maxRetryAttemptsOnThrottled.toInt)
-
-    val maxRetryWaitTimeSecs = config.getOrElse[String](CosmosDBConfig.QueryMaxRetryWaitTimeSecs, CosmosDBConfig.DefaultQueryMaxRetryWaitTimeSecs.toString)
-    connectionPolicy.getRetryOptions.setMaxRetryWaitTimeInSeconds(maxRetryWaitTimeSecs.toInt)
-
-    val preferredRegionList = config.get[String](CosmosDBConfig.PreferredRegionsList)
-    if (preferredRegionList.isDefined) {
-      logTrace(s"CosmosDBConnection::Input preferred region list: ${preferredRegionList.get}")
-      val preferredLocations = preferredRegionList.get.split(";").toSeq.map(_.trim)
-      connectionPolicy.setPreferredLocations(preferredLocations)
-    }
-
-    // Generate consistency level
-    val consistencyLevel = ConsistencyLevel.valueOf(config.get[String](CosmosDBConfig.ConsistencyLevel)
-      .getOrElse(CosmosDBConfig.DefaultConsistencyLevel))
-
-    AsyncClientConfiguration(
-      config.get[String](CosmosDBConfig.Endpoint).get,
-      config.get[String](CosmosDBConfig.Masterkey).get,
-      connectionPolicy,
-      consistencyLevel
-    )
-  }
+  
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -252,8 +252,16 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
     documentClient.readDocuments(collectionLink, feedOptions).getQueryIterable.iterator()
   }
 
-  def readChangeFeed(changeFeedOptions: ChangeFeedOptions, isStreaming: Boolean, shouldInferStreamSchema: Boolean): Tuple2[Iterator[Document], String] = {
-    logDebug(s"--> readChangeFeed, PageSize: ${changeFeedOptions.getPageSize().toString()}, ContinuationToken: ${changeFeedOptions.getRequestContinuation()}, PartitionId: ${changeFeedOptions.getPartitionKeyRangeId()}, ShouldInferSchema: ${shouldInferStreamSchema.toString()}")
+  def readChangeFeed(
+    changeFeedOptions: ChangeFeedOptions,
+    isStreaming: Boolean,
+    shouldInferStreamSchema: Boolean,
+    updateTokenFunc: Function3[String, String, String, Unit]
+    ): Iterator[Document] = {
+
+    val partitionId = changeFeedOptions.getPartitionKeyRangeId()
+
+    logDebug(s"--> readChangeFeed, PageSize: ${changeFeedOptions.getPageSize().toString()}, ContinuationToken: ${changeFeedOptions.getRequestContinuation()}, PartitionId: ${partitionId}, ShouldInferSchema: ${shouldInferStreamSchema.toString()}")
     
     // The ChangeFeed API in the SDK allows accessing the continuation token
     // from the latest HTTP Response
@@ -276,17 +284,18 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
     var lastProcessedIdBookmark = ""
 
     // The original continuation that has been passed to this method by the caller
-    var originalContinuation = changeFeedOptions.getRequestContinuation()
+    val originalContinuation = changeFeedOptions.getRequestContinuation()
+    var currentContinuation = originalContinuation
 
     // The next continuation token that is returned to the caller to continue
     // processing the change feed
     var nextContinuation = changeFeedOptions.getRequestContinuation()
-    if (originalContinuation != null && 
-        originalContinuation.contains("|"))
+    if (currentContinuation != null && 
+        currentContinuation.contains("|"))
     {
-      val continuationFragments = originalContinuation.split('|')
-      originalContinuation = continuationFragments(0)
-      changeFeedOptions.setRequestContinuation(originalContinuation)
+      val continuationFragments = currentContinuation.split('|')
+      currentContinuation = continuationFragments(0)
+      changeFeedOptions.setRequestContinuation(currentContinuation)
       lastProcessedIdBookmark = continuationFragments(1)
       foundBookmark = false
     }
@@ -295,12 +304,12 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
     // after a bookmark in the form of <blockStartContinuation>|<lastProcessedIdBookmark>
     // Meaning the <blockStartContinuation> needs to be at a previous or the same page as the change record
     // document with Id <lastProcessedIdBookmark>
-    var previousBlockStartContinuation = originalContinuation
+    var previousBlockStartContinuation = currentContinuation
 
     // blockStartContinuation is used as a place holder to store the feedResponse.getResponseContinuation()
     // of the previous HTTP response to be able to apply it to previousBlockStartContinuation
     // accordingly
-    var blockStartContinuation = originalContinuation
+    var blockStartContinuation = currentContinuation
 
     // This method can result in reading the next page of the changefeed and changing the continuation token header
     val feedResponse = documentClient.queryDocumentChangeFeed(collectionLink, changeFeedOptions)
@@ -309,7 +318,7 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
     // If processing from the beginning (no continuation token passed into this method)
     // it is safe to increase previousBlockStartContinuation here because we always at least return
     // one page
-    if (Option(originalContinuation).getOrElse("").isEmpty)
+    if (Option(currentContinuation).getOrElse("").isEmpty)
     {
       blockStartContinuation = feedResponse.getResponseContinuation()
       previousBlockStartContinuation = blockStartContinuation
@@ -392,7 +401,10 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
       }
       
       logDebug(s"<-- readChangeFeed, Count: ${cfDocuments.length.toString()}, NextContinuation: ${nextContinuation}")
-      Tuple2.apply(cfDocuments.iterator(), nextContinuation)
+      
+      updateTokenFunc(originalContinuation, nextContinuation, partitionId)
+      logDebug(s"changeFeedOptions.partitionKeyRangeId = ${partitionId}, continuation = $originalContinuation, new token = ${nextContinuation}")
+      cfDocuments.iterator()
     } else 
     {
       // next Continuation Token is plain and simple when not using Streaming because
@@ -400,7 +412,12 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
       // in this case - so there doesn't need to be any suffix in the continutaion token returned
       nextContinuation = feedResponse.getResponseContinuation()
       logDebug(s"<-- readChangeFeed, Non-Streaming, NextContinuation: ${nextContinuation}")
-      Tuple2.apply(feedResponse.getQueryIterator, nextContinuation)
+      new ContinuationTokenTrackingIterator[Document](
+            feedResponse,
+            updateTokenFunc,
+            (msg:String) => logDebug(msg),
+            partitionId
+          )
     }
   }
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
@@ -323,12 +323,6 @@ object CosmosDBSpark extends CosmosDBLoggingTrait {
       }
       documents.add(document.toJson())
       if (documents.size() >= writingBatchSize) {
-        logDebug("Documents to be ingested: " + getDocumentsDebugString(
-            connection,
-            documents,
-            partitionKeyDefinition
-          ))
-
         bulkImportResponse = importer.importAll(documents, upsert, false, maxConcurrencyPerPartitionRange)
         if (!bulkImportResponse.getErrors.isEmpty) {
           throw new Exception("Errors encountered in bulk import API execution. Exceptions observed:\n" + bulkImportResponse.getErrors.toString)
@@ -355,11 +349,6 @@ object CosmosDBSpark extends CosmosDBLoggingTrait {
       }
     })
     if (documents.size() > 0) {
-      logDebug("Documents to be ingested: " + getDocumentsDebugString(
-          connection,
-          documents,
-          partitionKeyDefinition
-        ))
       bulkImportResponse = importer.importAll(documents, upsert, false, maxConcurrencyPerPartitionRange)
       if (!bulkImportResponse.getErrors.isEmpty) {
         throw new Exception("Errors encountered in bulk import API execution. Exceptions observed:\n" + bulkImportResponse.getErrors.toString)

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -80,6 +80,20 @@ object CosmosDBConfig {
   val ChangeFeedCheckpointLocation = "changefeedcheckpointlocation"
   val InferStreamSchema = "inferstreamschema"
 
+  // Structured Streaming WriteStream retry policy related
+  val WriteStreamRetryPolicyKind = "writestreamretrypolicy.kind"
+  val MaxTransientRetryCount = "writestreamretrypolicy.maxtransientretrycount"
+  val MaxTransientRetryDurationInMs = "writestreamretrypolicy.maxtransientretrydurationinms"
+  val MaxTransientRetryDelayInMs = "writestreamretrypolicy.maxtransientretrydelayinms"
+  val PoisonMessageLocation = "writestreamretrypolicy.poisonmessagelocation"
+  val TreatUnknownExceptionsAsTransient = "writestreamretrypolicy.treatunknownexceptionsastransient"
+  val DefaultWriteStreamRetryPolicyKind = "NoRetries"
+  val DefaultMaxTransientRetryCount = Int.MaxValue
+  val DefaultMaxTransientRetryDurationInMs = 1000 * 60 * 60 // 1 hour
+  val DefaultMaxTransientRetryDelayInMs = 1000 // 1 second
+  val DefaultPoisonMessageLocation = ""
+  val DefaultTreatUnknownExceptionsAsTransient = true
+  
   // Not a config, constant
   val StreamingTimestampToken = "tsToken"
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -90,7 +90,7 @@ object CosmosDBConfig {
   val DefaultWriteStreamRetryPolicyKind = "NoRetries"
   val DefaultMaxTransientRetryCount = Int.MaxValue
   val DefaultMaxTransientRetryDurationInMs = 1000 * 60 * 60 // 1 hour
-  val DefaultMaxTransientRetryDelayInMs = 1000 // 1 second
+  val DefaultMaxTransientRetryDelayInMs = 100 // 0.1 second
   val DefaultPoisonMessageLocation = ""
   val DefaultTreatUnknownExceptionsAsTransient = true
   

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSink.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSink.scala
@@ -38,9 +38,9 @@ private[spark] class CosmosDBSink(sqlContext: SQLContext,
   
   override def addBatch(batchId: Long, data: DataFrame): Unit = {
     if (batchId <= lastBatchId) {
-      logError(s"Rerun batchId $batchId")
+      logDebug(s"Rerun batchId $batchId")
     } else {
-      logError(s"Run batchId $batchId")
+      logDebug(s"Run batchId $batchId")
       lastBatchId = batchId
     }
 
@@ -48,10 +48,9 @@ private[spark] class CosmosDBSink(sqlContext: SQLContext,
     val schemaOutput = queryExecution.analyzed.output
     val config = Config(configMap)
     val rdd = queryExecution.toRdd
-    logError(s"Partition Count:" + rdd.partitions.size)
+    logTrace(s"Partition Count:" + rdd.partitions.size)
 
     rdd.foreachPartition( iter => {
-      logError(s"Creating StreamingWriteTask")
       val writeTask = new StreamingWriteTask()
       writeTask.importStreamingData(iter, schemaOutput, config, retryPolicy)
     })

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamPoisonMessageNotificationHandler.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamPoisonMessageNotificationHandler.scala
@@ -1,0 +1,30 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import com.microsoft.azure.cosmosdb.Document
+
+trait CosmosDBWriteStreamPoisonMessageNotificationHandler
+{
+    def onPoisonMessage(lastError: Throwable,  document: Document)
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicy.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicy.scala
@@ -1,0 +1,89 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import com.microsoft.azure.cosmosdb.{Document, ResourceResponse, RequestOptions}
+import com.microsoft.azure.cosmosdb.spark.CosmosDBLoggingTrait
+import com.microsoft.azure.cosmosdb.spark.config.{Config, CosmosDBConfig}
+import java.time.Instant;
+import java.time.temporal.ChronoField;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.TimeUnit;
+import rx.Observable
+
+class CosmosDBWriteStreamRetryPolicy(configMap: Map[String, String]) 
+    extends CosmosDBLoggingTrait
+    with Serializable
+{
+    val config = getConfig(configMap)
+    val rnd = scala.util.Random
+    private lazy val notificationHandler: CosmosDBWriteStreamPoisonMessageNotificationHandler = {
+        getNotificationHandler(configMap)
+    }
+
+    def getConfig(configMap: Map[String, String]) : CosmosDBWriteStreamRetryPolicyConfig =
+    {
+        val retryPolicyKind = configMap
+        .getOrElse(
+            CosmosDBConfig.WriteStreamRetryPolicyKind,
+            String.valueOf(CosmosDBConfig.DefaultWriteStreamRetryPolicyKind))
+        
+        val retryPolicyConfig = retryPolicyKind match {
+            case kind if kind matches "(?i)NoRetries" => new NoRetriesCosmosDBWriteStreamRetryPolicyConfig()
+            case kind if kind matches "(?i)Default" => new DefaultCosmosDBWriteStreamRetryPolicyConfig(configMap)
+            case _ => new NoRetriesCosmosDBWriteStreamRetryPolicyConfig()
+        }
+
+        logError("Retry policy kind '" + retryPolicyKind + "' --> " + retryPolicyConfig)
+        // TODO logDebug("Retry policy kind '" + retryPolicyKind + "' --> " + retryPolicyConfig)
+
+        retryPolicyConfig
+    }
+
+    def getNotificationHandler(configMap: Map[String, String]) : CosmosDBWriteStreamPoisonMessageNotificationHandler =
+    {
+        new DefaultCosmosDBWriteStreamPoisonMessageNotificationHandler(configMap)
+    }
+
+    def process(document: Document,
+                requestOptions: RequestOptions,
+                task: Function2[Document, RequestOptions, Observable[ResourceResponse[Document]]]): Observable[ResourceResponse[Document]] = {
+        val maxRetries = this.config.getMaxTransientRetryCount()
+        val maxRetryDelayInMs = this.config.getMaxTransientRetryDelayInMs()
+        val retryUntil = Instant.now().get(ChronoField.MILLI_OF_SECOND) + this.config.getMaxTransientRetryDurationInMs();
+        val attempts = new AtomicLong(0L);
+
+        CosmosDBWriteStreamRetryPolicyUtil.ProcessWithRetries(
+            document,
+            requestOptions,
+            task,
+            this.config.isTransient,
+            (msg: String) => logError(msg),
+            (throwable: Throwable, document: Document) => this.notificationHandler.onPoisonMessage(throwable, document),
+            this.rnd,
+            maxRetries,
+            maxRetryDelayInMs,
+            retryUntil,
+            attempts)
+    } 
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicy.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicy.scala
@@ -62,8 +62,7 @@ class CosmosDBWriteStreamRetryPolicy(configMap: Map[String, String])
             case _ => new NoRetriesCosmosDBWriteStreamRetryPolicyConfig()
         }
 
-        logError("Retry policy kind '" + retryPolicyKind + "' --> " + retryPolicyConfig)
-        // TODO logDebug("Retry policy kind '" + retryPolicyKind + "' --> " + retryPolicyConfig)
+        logDebug("Retry policy kind '" + retryPolicyKind + "' --> " + retryPolicyConfig)
 
         retryPolicyConfig
     }
@@ -99,7 +98,7 @@ class CosmosDBWriteStreamRetryPolicy(configMap: Map[String, String])
             requestOptions,
             task,
             this.config.isTransient _,
-            (msg: String) => logError(msg),
+            loggingAction = (msg: String) => logDebug(msg),
             (throwable: Throwable, document: Document) => this.notificationHandler.onPoisonMessage(throwable, document),
             this.rnd,
             maxRetries,

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicyConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBWriteStreamRetryPolicyConfig.scala
@@ -1,0 +1,34 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+trait CosmosDBWriteStreamRetryPolicyConfig 
+{
+  def isTransient(t: Throwable) : Boolean
+
+  def getMaxTransientRetryCount() : Int
+
+  def getMaxTransientRetryDurationInMs() : Int
+
+  def getMaxTransientRetryDelayInMs() : Int
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamPoisonMessageNotificationHandler.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamPoisonMessageNotificationHandler.scala
@@ -1,0 +1,76 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import com.microsoft.azure.cosmosdb.{Document, ResourceResponse, RequestOptions}
+import com.microsoft.azure.cosmosdb.spark.config.{Config, CosmosDBConfig}
+import com.microsoft.azure.cosmosdb.spark.CosmosDBLoggingTrait
+import com.microsoft.azure.cosmosdb.spark.util.HdfsUtils
+
+import java.io.{FileNotFoundException, PrintWriter, StringWriter}
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.atomic.AtomicLong;
+
+class DefaultCosmosDBWriteStreamPoisonMessageNotificationHandler(configMap: Map[String, String])
+    extends CosmosDBWriteStreamPoisonMessageNotificationHandler
+    with CosmosDBLoggingTrait
+    with Serializable
+ {
+    private val config = Config(configMap)
+
+    private val sequenceNumber = new AtomicLong(0L)
+
+    private val poisonMessageLocation: String = config
+        .getOrElse(
+            CosmosDBConfig.PoisonMessageLocation,
+            String.valueOf(CosmosDBConfig.DefaultPoisonMessageLocation))
+    
+    private lazy val hdfsUtils: HdfsUtils = {
+        HdfsUtils(configMap)
+    }
+
+    def onPoisonMessage(lastError: Throwable, document: Document) =
+    {
+        val sw = new StringWriter
+        lastError.printStackTrace(new PrintWriter(sw))
+
+        val callstack = sw.toString()
+        val error = lastError.getMessage() + System.lineSeparator + callstack
+        val id = document.getId() 
+
+        val payload = document.toJson()
+
+        logError(s"POSION MESSAGE Id: ${id}, Error: ${error}, Document payload: ${payload}")
+
+        if (this.poisonMessageLocation != "")
+        {
+            val prefix = DateTimeFormatter.ISO_INSTANT.format(Instant.now()) + "_" + sequenceNumber.incrementAndGet().toString()
+            val errorFile = prefix + "_" + id + "_Error.txt"
+            val payloadFile = prefix + "_" + id + "_Payload.json"   
+
+            this.hdfsUtils.write(this.poisonMessageLocation, errorFile, error)
+            this.hdfsUtils.write(this.poisonMessageLocation, payloadFile, payload)
+        }
+    }    
+ }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamPoisonMessageNotificationHandler.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamPoisonMessageNotificationHandler.scala
@@ -56,18 +56,18 @@ class DefaultCosmosDBWriteStreamPoisonMessageNotificationHandler(configMap: Map[
         lastError.printStackTrace(new PrintWriter(sw))
 
         val callstack = sw.toString()
-        val error = lastError.getMessage() + System.lineSeparator + callstack
+        val error = s"${lastError.getMessage()}${System.lineSeparator}${callstack}"
         val id = document.getId() 
 
         val payload = document.toJson()
 
-        logError(s"POSION MESSAGE Id: ${id}, Error: ${error}, Document payload: ${payload}")
+        logWarning(s"POSION MESSAGE Id: ${id}, Error: ${error}, Document payload: ${payload}")
 
         if (this.poisonMessageLocation != "")
         {
-            val prefix = DateTimeFormatter.ISO_INSTANT.format(Instant.now()) + "_" + sequenceNumber.incrementAndGet().toString()
-            val errorFile = prefix + "_" + id + "_Error.txt"
-            val payloadFile = prefix + "_" + id + "_Payload.json"   
+            val prefix = s"${DateTimeFormatter.ISO_INSTANT.format(Instant.now())}_${sequenceNumber.incrementAndGet().toString()}"
+            val errorFile = s"${prefix}_${id}_Error.txt"
+            val payloadFile = s"${prefix}_${id}_Payload.json"   
 
             this.hdfsUtils.write(this.poisonMessageLocation, errorFile, error)
             this.hdfsUtils.write(this.poisonMessageLocation, payloadFile, payload)

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamRetryPolicyConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamRetryPolicyConfig.scala
@@ -1,0 +1,92 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import java.io.{FileNotFoundException, PrintWriter, StringWriter}
+
+import com.microsoft.azure.cosmosdb.spark.CosmosDBLoggingTrait
+import com.microsoft.azure.cosmosdb.spark.config.{Config, CosmosDBConfig}
+
+class DefaultCosmosDBWriteStreamRetryPolicyConfig(configMap: Map[String, String])
+    extends CosmosDBWriteStreamRetryPolicyConfig
+    with CosmosDBLoggingTrait
+    with Serializable
+ {
+    val config = Config(configMap)
+
+    val maxTransientRetryCount: Int = config
+        .getOrElse(
+            CosmosDBConfig.MaxTransientRetryCount,
+            String.valueOf(CosmosDBConfig.DefaultMaxTransientRetryCount))
+        .toInt
+
+    val maxTransientRetryDurationInMs: Int = config
+        .getOrElse(
+            CosmosDBConfig.MaxTransientRetryDurationInMs,
+            String.valueOf(CosmosDBConfig.DefaultMaxTransientRetryDurationInMs))
+        .toInt
+
+    val maxTransientRetryDelayInMs: Int = config
+        .getOrElse(
+            CosmosDBConfig.MaxTransientRetryDelayInMs,
+            String.valueOf(CosmosDBConfig.DefaultMaxTransientRetryDelayInMs))
+        .toInt
+
+    val treatUnknownExceptionsAsTransient: Boolean = config
+        .getOrElse(
+            CosmosDBConfig.TreatUnknownExceptionsAsTransient,
+            String.valueOf(CosmosDBConfig.DefaultTreatUnknownExceptionsAsTransient))
+        .toBoolean
+
+    def isTransient(t: Throwable) : Boolean = {
+        val sw = new StringWriter
+        t.printStackTrace(new PrintWriter(sw))
+
+        if (treatUnknownExceptionsAsTransient)
+        {
+            //logWarning(s"TRANSIENT error: ${t.getMessage}, CallStack: ${sw.toString}")
+            logError(s"TRANSIENT error: ${t.getMessage}, CallStack: ${sw.toString}")
+            true
+        }
+        else
+        {
+            logError(s"NON-TRANSIENT error: ${t.getMessage}, CallStack: ${sw.toString}")
+            false
+        }
+    }
+
+    // Retrying endlessly ()
+    def getMaxTransientRetryCount() : Int = {
+        maxTransientRetryCount
+    }
+
+    // Retrying for up to 1 hour 
+    def getMaxTransientRetryDurationInMs() : Int = {
+        maxTransientRetryDurationInMs
+    }
+
+    // Waiting up to one second between retries
+    def getMaxTransientRetryDelayInMs() : Int = {
+        maxTransientRetryDelayInMs
+    }
+ }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamRetryPolicyConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/DefaultCosmosDBWriteStreamRetryPolicyConfig.scala
@@ -64,8 +64,7 @@ class DefaultCosmosDBWriteStreamRetryPolicyConfig(configMap: Map[String, String]
 
         if (treatUnknownExceptionsAsTransient)
         {
-            //logWarning(s"TRANSIENT error: ${t.getMessage}, CallStack: ${sw.toString}")
-            logError(s"TRANSIENT error: ${t.getMessage}, CallStack: ${sw.toString}")
+            logWarning(s"TRANSIENT error: ${t.getMessage}, CallStack: ${sw.toString}")
             true
         }
         else

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/NoRetriesCosmosDBWriteStreamRetryPolicyConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/NoRetriesCosmosDBWriteStreamRetryPolicyConfig.scala
@@ -1,0 +1,53 @@
+/**
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
+package com.microsoft.azure.cosmosdb.spark.streaming
+
+import java.io.{FileNotFoundException, PrintWriter, StringWriter}
+
+import com.microsoft.azure.cosmosdb.spark.CosmosDBLoggingTrait
+import com.microsoft.azure.cosmosdb.spark.config.{Config, CosmosDBConfig}
+
+class NoRetriesCosmosDBWriteStreamRetryPolicyConfig
+ extends CosmosDBWriteStreamRetryPolicyConfig
+ with CosmosDBLoggingTrait
+ with Serializable
+{
+    def isTransient(t: Throwable) : Boolean = {
+        val sw = new StringWriter
+        t.printStackTrace(new PrintWriter(sw))
+        logError(s"NON-TRANSIENT error: ${t.getMessage}, CallStack: ${sw.toString}")
+        false
+    }
+
+    def getMaxTransientRetryCount() : Int = {
+        0
+    }
+
+    def getMaxTransientRetryDurationInMs() : Int = {
+        0
+    }
+
+    def getMaxTransientRetryDelayInMs() : Int = {
+        0
+    }
+}

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/StreamingUtils.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/StreamingUtils.scala
@@ -87,6 +87,6 @@ class StreamingWriteTask extends Serializable with CosmosDBLoggingTrait {
     val count = result.count().toBlocking().last()
 
     var latency = Math.abs(ChronoUnit.MILLIS.between(LocalDateTime.now(), startTime))
-    logError(s"Batch of ${count} records written with latency ${latency} milliseconds")
+    logInfo(s"Batch of ${count} records written with latency ${latency} milliseconds")
   }
 }


### PR DESCRIPTION
Changes:
- Fixing a bug where the bookmark/lease wasn't correctly updated when processing changefeed in batch mode
- Fixing a bug where partition key values weren't extracted correctly for nested partition keys.
- Adding the capability to define a custom retry policy and poison message handling for stream writes
- Updating dependency references to consume latest version of the sync CosmsoDB V2 SDK and bulk import library