### PR TITLE
change to honor ResourceToken in AsyncConnection

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/AsyncCosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/AsyncCosmosDBConnection.scala
@@ -103,9 +103,11 @@ object AsyncCosmosDBConnection {
     val consistencyLevel = ConsistencyLevel.valueOf(config.get[String](CosmosDBConfig.ConsistencyLevel)
       .getOrElse(CosmosDBConfig.DefaultConsistencyLevel))
 
+    val resourceToken = config.getOrElse[String](CosmosDBConfig.ResourceToken, "")
+
     AsyncClientConfiguration(
       config.get[String](CosmosDBConfig.Endpoint).get,
-      config.get[String](CosmosDBConfig.Masterkey).get,
+      config.getOrElse[String](CosmosDBConfig.Masterkey, resourceToken),
       connectionPolicy,
       consistencyLevel
     )

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-2.0.3"
+  val currentVersion = "2.4.0_2.11-2.1.0"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }


### PR DESCRIPTION
Problem:
When ResourceToken is being used instead of the Key in Batch mode, the CollectionThroughput is being queried and it fails if the Resource does not have permission to get the CollectionThroughput. 

The CollectionThroughput is required only for BulkExecutor and not for the AsyncConnection. So, 
customers using ResourceToken with restrictive access would have to use AsyncConnection. However, the AsyncConnection currently does not honor the ResourceToken and works only with Key. 

Changes:

- Query the CollectionThroughput only in the case of BulkImport or BulkUpdate and not in AsyncConnection mode
- Add the option of using ResourceToken along with Key in AsyncConnection