### PR TITLE
Fixing metadata throttling issue caused in scenarios with frequent writes of small batches  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.3</version>
+    <version>2.1.4</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-2.1.3"
+  val currentVersion = "2.4.0_2.11-2.1.4"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }


### PR DESCRIPTION
**Scenario**
Failures of bulk updates/imports when issueing frequent writes of small batches.

**Problem:**
Each bulkUpdate and bulkInsert call calls getCollectionThroughput that triggers 1 or 2 CosmosDB queries. This is an operation counting against the metadata RU budget - with multiple partitions it can easily result in metadata throttling which ultimately results in failures of the bulk operations - accelerated due to a very aggressive retry-policy for service unavailable errors/Gone exceptions.

**Fix:**
Cache the result of the collection throughput so that the query is made once per connection/per partition.
Also adding a retry delay for service unavailable/gone exception (partition splits)

**Limitations:**
If the RU/s are updated then the application will not pick up the change until it is restarted or the client gets reinitialized for example after partition splits.

