### PR TITLE
Fix collection throughput caching logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.4</version>
+    <version>2.1.5</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-2.1.4"
+  val currentVersion = "2.4.0_2.11-2.1.5"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -23,6 +23,7 @@
 package com.microsoft.azure.cosmosdb.spark
 
 import java.lang.management.ManagementFactory
+import java.util.{Timer, TimerTask}
 
 import com.microsoft.azure.cosmosdb.spark.config._
 import com.microsoft.azure.documentdb
@@ -137,9 +138,29 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
   private var database: Database = _
   private var collectionThroughput: Option[Int] = None
 
+  private val rnd = scala.util.Random
+
+  private val refreshDelay : Long = (10 * 60 * 1000) + rnd.nextInt(5 * 60 * 1000) // in 10 - 15 minutes
+  private val refreshPeriod : Long = 15 * 60 * 1000 // every 15 minutes
+
+  // main purpose of the time is to allow bulk operations to consume
+  // additional throughput when more RUs are getting provisioned
+  private val timerName = "collectionthroughput-refresh-timer"
+  private val timer: Timer = new Timer(timerName)
+
   @transient private var bulkImporter: DocumentBulkExecutor = _
 
   private var documentClient: DocumentClient = CosmosDBConnection.getClient(connectionMode, getClientConfiguration(config))
+
+  logInfo(s"${timerName}: scheduling timer - delay: ${refreshDelay} ms, period: ${refreshPeriod} ms")
+  timer.schedule(
+    new TimerTask { def run() = {
+      collectionThroughput = None
+      logInfo(s"${timerName}: Resetting cached collection throughput")
+    }},
+    refreshDelay, 
+    refreshPeriod
+  )
 
   def getPartitionKeyDefinition(partitionKeyDefinition: Option[String]) : PartitionKeyDefinition = {
     if (partitionKeyDefinition.isDefined) {
@@ -233,14 +254,20 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
           offer.getContent.getInt("offerThroughput")
 
         this.collectionThroughput = Some(collectionThroughput)
+
+        logInfo(s"getCollectionThroughput: ${collectionThroughput}")        
         collectionThroughput
       }
     }  
   }
 
-  def reinitializeClient () = {
+  def reinitializeClient (shouldReinitializeThroughput: Boolean) = {
     documentClient = CosmosDBConnection.reinitializeClient(getCollection, connectionMode, getClientConfiguration(config))
-    collectionThroughput = None
+
+    if (shouldReinitializeThroughput) {
+      logInfo("reinitializeClient: Resetting cached collection throughput")
+      collectionThroughput = None
+    }
   }
 
   def queryDocuments (queryString : String,

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/partitioner/CosmosDBPartitioner.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/partitioner/CosmosDBPartitioner.scala
@@ -50,7 +50,7 @@ class CosmosDBPartitioner() extends Partitioner[Partition] with CosmosDBLoggingT
                         requiredColumns: Array[String] = Array(),
                         filters: Array[Filter] = Array()): Array[Partition] = {
     var connection: CosmosDBConnection = new CosmosDBConnection(config)
-    connection.reinitializeClient()
+    connection.reinitializeClient(shouldReinitializeThroughput = false)
    
     // CosmosDB source
     var query: String = FilterConverter.createQueryString(requiredColumns, filters)

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -400,7 +400,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         val dcx: DocumentClientException = ex.asInstanceOf[DocumentClientException]
         if (dcx.getStatusCode == StatusCodes.SERVICE_UNAVAILABLE) {
           logError("Service Unavailable")
-          connection.reinitializeClient()
+          connection.reinitializeClient(shouldReinitializeThroughput = false)
         }
       } else if (ex.isInstanceOf[IllegalStateException]
         && ex.getCause != null
@@ -408,14 +408,14 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         logError("Illegal State Exception with Service Unavailable")
         val dcx: DocumentClientException = ex.getCause.asInstanceOf[DocumentClientException]
         if (dcx.getStatusCode == StatusCodes.SERVICE_UNAVAILABLE) {
-          connection.reinitializeClient()
+          connection.reinitializeClient(shouldReinitializeThroughput = false)
         }
       }
     })
 
     // Register an on-task-completion callback to close the input stream.
     taskContext.addTaskCompletionListener((context: TaskContext) => {
-      connection.reinitializeClient()
+      connection.reinitializeClient(shouldReinitializeThroughput = false)
       closeIfNeeded()
     })
 
@@ -438,7 +438,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         |status code ${exception.getStatusCode}, substatus ${exception.getSubStatusCode} 
         |Retry delay (ms): ${retryDelayInMs}""")
       Thread.sleep(retryDelayInMs)
-      connection.reinitializeClient()
+      connection.reinitializeClient(shouldReinitializeThroughput = true)
     } else {
       logWarning(s"""UNHANDLED STREAMING EXCEPTION: ${exception.getMessage} 
       |${exception.getStatusCode} ${exception.getSubStatusCode}""")


### PR DESCRIPTION
Fix collection throughput caching logic. Preventing refreshes on client reinitialization except for partition splits and also adding refreshes in regular time intervals
