### PR TITLE
Fix for streaming to handle new child partitions and Null exception fix for checkpoint writes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.0.0"
+  val currentVersion = "2.4.0_2.11-3.0.4"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/HdfsUtils.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/HdfsUtils.scala
@@ -45,12 +45,12 @@ case class HdfsUtils(configMap: Map[String, String]) extends CosmosDBLoggingTrai
   def write(base: String, filePath: String, content: String): Unit = {
     val path = new Path(base + "/" + filePath)
     retry(maxRetryCount) {
-      val os = fs.create(path)
-      os.writeUTF(content)
-      os.close()
+      if (content != null && !content.isEmpty) {
+        val os = fs.create(path)
+        os.writeUTF(content)
+        os.close()
+      }
     }
-
-    logInfo(s"Write $content for $path")
   }
 
   def read(base: String, filePath: String): String = {


### PR DESCRIPTION
**Problems:**
1. The new child partitions that were created in between streaming micro-batch executions would not have checkpoint files during the first execution. The parents' checkpoint files lookup is currently not being done in streaming. This results in the loosing the gathered records in the new child partitions for the first execution. 

2. When a new child partition has multiple levels of parents such as the parent hierarchy of ["8","41","89","177"], the first parent is picked up and is used to lookup its token. This results in going back to an older token. The latest parent in the hierarchy needs to be picked up. 

3. If one or more of the partitions in source cosmos db collection does not have records, the checkpoint write would not have any LSN and fails with Nullpointer execption. This also creates blank checkpoint files and the checkpoint read also fails.  


**Changes:**
1. Lookup parent checkpoint files when a new child partition is seen.

2. Get the latest parent in the parent hierarchy when a new child partition has multiple levels of parents.

3. Do not write to the checkpoint files if the given partition does not have records / LSN value 
