### PR TITLE
Reduce the size of data sent to driver when reading

### DIFF
--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -50,7 +50,7 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
   def getAllPartitions: List[PartitionKeyRange] = {
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
     val ranges = documentClient.readPartitionKeyRanges(collectionLink, null.asInstanceOf[FeedOptions])
-    toList(ranges)
+    getListFromFeedResponse(ranges)
   }
 
   def getDocumentBulkImporter: DocumentBulkExecutor = {
@@ -66,20 +66,20 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
 
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
     val feedResponse: FeedResponse[Document] = documentClient.queryDocuments(collectionLink, new SqlQuerySpec(queryString), feedOpts)
-    toList(feedResponse).iterator
+    getListFromFeedResponse(feedResponse).iterator
   }
 
   def queryDocuments(collectionLink: String, queryString: String,
                      feedOpts: FeedOptions): Iterator[Document] = {
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
     val feedResponse: FeedResponse[Document] = documentClient.queryDocuments(collectionLink, new SqlQuerySpec(queryString), feedOpts)
-    toList(feedResponse).iterator
+    getListFromFeedResponse(feedResponse).iterator
   }
 
   def readDocuments(feedOptions: FeedOptions): Iterator[Document] = {
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
     val resp: FeedResponse[Document] = documentClient.readDocuments(collectionLink, feedOptions)
-    toList(resp).iterator
+    getListFromFeedResponse(resp).iterator
   }
 
   /**
@@ -89,7 +89,7 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
    * @param response
    * @return
    */
-  private def toList[T <: com.microsoft.azure.documentdb.Resource : ClassTag](response: FeedResponse[T]): List[T] = {
+  private def getListFromFeedResponse[T <: com.microsoft.azure.documentdb.Resource : ClassTag](response: FeedResponse[T]): List[T] = {
     response
       .getQueryIterable
       .iterator

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -29,6 +29,7 @@ import com.microsoft.azure.documentdb.bulkexecutor.DocumentBulkExecutor
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
 import scala.language.implicitConversions
+import scala.reflect.ClassTag
 import scala.util.control.Breaks._
 
 private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLoggingTrait with Serializable {
@@ -46,10 +47,10 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
     CosmosDBConnectionCache.reinitializeClient(clientConfig)
   }
 
-  def getAllPartitions: Array[PartitionKeyRange] = {
+  def getAllPartitions: List[PartitionKeyRange] = {
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
     val ranges = documentClient.readPartitionKeyRanges(collectionLink, null.asInstanceOf[FeedOptions])
-    ranges.getQueryIterator.toArray
+    toList(ranges)
   }
 
   def getDocumentBulkImporter: DocumentBulkExecutor = {
@@ -64,20 +65,35 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
                      feedOpts: FeedOptions): Iterator[Document] = {
 
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
-    val feedResponse = documentClient.queryDocuments(collectionLink, new SqlQuerySpec(queryString), feedOpts)
-    feedResponse.getQueryIterable.iterator()
+    val feedResponse: FeedResponse[Document] = documentClient.queryDocuments(collectionLink, new SqlQuerySpec(queryString), feedOpts)
+    toList(feedResponse).iterator
   }
 
   def queryDocuments(collectionLink: String, queryString: String,
                      feedOpts: FeedOptions): Iterator[Document] = {
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
-    val feedResponse = documentClient.queryDocuments(collectionLink, new SqlQuerySpec(queryString), feedOpts)
-    feedResponse.getQueryIterable.iterator()
+    val feedResponse: FeedResponse[Document] = documentClient.queryDocuments(collectionLink, new SqlQuerySpec(queryString), feedOpts)
+    toList(feedResponse).iterator
   }
 
   def readDocuments(feedOptions: FeedOptions): Iterator[Document] = {
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
-    documentClient.readDocuments(collectionLink, feedOptions).getQueryIterable.iterator()
+    val resp: FeedResponse[Document] = documentClient.readDocuments(collectionLink, feedOptions)
+    toList(resp).iterator
+  }
+
+  /**
+   * Takes the results from a FeedResponse and puts them in a standard List. The FeedResponse
+   * otherwise hides a lot of extra fields behind the Iterator[T] interface that would still
+   * need to be serialized when being collected on the driver.
+   * @param response
+   * @return
+   */
+  private def toList[T <: com.microsoft.azure.documentdb.Resource : ClassTag](response: FeedResponse[T]): List[T] = {
+    response
+      .getQueryIterable
+      .iterator
+      .toList
   }
 
   def readChangeFeed(changeFeedOptions: ChangeFeedOptions,


### PR DESCRIPTION
**Problem**
Our jobs are often failing with maxResultSize exceeded errors.  MaxResultSize is a configurable limit on the amount of data that can be collected from executors to the driver.  It exists to prevent runaway memory usage assuming that you rarely or shouldn't need to collect that much data.

We reduced the batch size and the maxRatePerPartition but it still occurred so I started looking deeper.

Our CosmosDB query is 47kb, and the result size is 7kb, however 1MB of data for that result set was being returned to the driver.  If you have thousands of these jobs then you'll eventually hit the 4gb default limit, and the 12gb other limit we pushed to.

**Before**
5 cores per 1 executor so there are 5 concurrent reads here.
```
20/06/03 17:36:27 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 42
20/06/03 17:36:27 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 41
20/06/03 17:36:27 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 19
20/06/03 17:36:27 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 15
20/06/03 17:36:27 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 12
20/06/03 17:36:27 INFO CodeGenerator: Code generated in 12.291755 ms
20/06/03 17:36:27 INFO CodeGenerator: Code generated in 10.147406 ms
20/06/03 17:36:27 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/03 17:36:27 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/03 17:36:27 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/03 17:36:27 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/03 17:36:27 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/03 17:36:27 INFO CosmosDBConnectionCache: throughput-refresh-timer: scheduling timer - delay: 877093 ms, period: 900000 ms
20/06/03 17:36:27 INFO DocumentClient: Initializing DocumentClient with serviceEndpoint [https://<snip>.documents.azure.com:443/]
20/06/03 17:36:27 INFO CosmosDBConnectionCache: Creating new ClientCacheEntry#732056112(DocumentClient#1876195947)
20/06/03 17:36:27 INFO CosmosDBConnectionCache: Updated ContainerMetadata for ClientCacheEntry#1768469820(DocumentClient#1876195947, Contain
20/06/03 17:36:27 WARN ServiceJNIWrapper: 'Linux' with 'amd64' system is not compatible with native library. JNI not loaded.
20/06/03 17:36:28 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 41
20/06/03 17:36:28 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 12
20/06/03 17:36:28 INFO Executor: Finished task 24.0 in stage 86.0 (TID 1842). 940207 bytes result sent to driver
20/06/03 17:36:28 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 19
20/06/03 17:36:28 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 42
20/06/03 17:36:28 INFO Executor: Finished task 4.0 in stage 86.0 (TID 1822). 940207 bytes result sent to driver
20/06/03 17:36:28 INFO Executor: Finished task 84.0 in stage 86.0 (TID 1902). 940336 bytes result sent to driver
```

**Cause**
Internally `CosmosDBRDD` creates a `CosmosDBRDDIterator` and `CosmosDBRDDIterator.queryDocuments` will call `connection.queryDocuments(queryString, feedOpts)` to get an `Iterator[Document]`.  This iterator is actually a cast of the java `FeedResponse`.  I believe this is the cause of the discrepancy - it's trying to collect all the FeedResponses instead of just the result of the queries back to the driver, and `FeedResponse` is a _very_ large object.

**Solution**
Copy the results to a new list and return that, leaving the FeedResponse on the executor.

**After*
So far it's looking better - 47kb instead of 1MB. There'll always be overhead but this is way better.

```
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 39
20/06/05 21:43:58 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 44
20/06/05 21:43:58 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 53
20/06/05 21:43:58 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: Start CosmosDBRDD compute task for partition key range id 34
20/06/05 21:43:58 INFO CosmosDBRDDIterator: CosmosDBRDDIterator::LazyReader, created query string: SELECT c.id, c.label, c.partitionKey FROM
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 53
20/06/05 21:43:58 INFO Executor: Finished task 4207.0 in stage 1327.0 (TID 110787). 47622 bytes result sent to driver
20/06/05 21:43:58 INFO CoarseGrainedExecutorBackend: Got assigned task 110862
20/06/05 21:43:58 INFO Executor: Running task 4282.0 in stage 1327.0 (TID 110862)
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 4
20/06/05 21:43:58 INFO Executor: Finished task 4135.0 in stage 1327.0 (TID 110715). 47622 bytes result sent to driver
20/06/05 21:43:58 INFO CoarseGrainedExecutorBackend: Got assigned task 110887
20/06/05 21:43:58 INFO Executor: Running task 4307.0 in stage 1327.0 (TID 110887)
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 34
20/06/05 21:43:58 INFO Executor: Finished task 4229.0 in stage 1327.0 (TID 110809). 47622 bytes result sent to driver
20/06/05 21:43:58 INFO CoarseGrainedExecutorBackend: Got assigned task 110902
20/06/05 21:43:58 INFO Executor: Running task 4322.0 in stage 1327.0 (TID 110902)
20/06/05 21:43:58 INFO CosmosDBRDD: CosmosDBRDD:compute: CosmosDBRDD compute task completed for partition key range id 39
20/06/05 21:43:58 INFO Executor: Finished task 4195.0 in stage 1327.0 (TID 110775). 47622 bytes result sent to driver
20/06/05 21:43:58 INFO CoarseGrainedExecutorBackend: Got assigned task 110903
```