### PR TITLE
Adds support for bulk updates with nested partition keys and fixes serialization issues for Float, Decimal and Timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 3.0.9
+## 3.1.0
+- Adds support for bulk updates when using nested partition keys
 - Adds support for Decimal and Float data types during writes to Cosmos DB.
+- Adds support for Timestamp types when they are using Long (unix Epoch) as a value
 
 ## 3.0.8
 - Fixes type cast exception when using "WriteThroughputBudget" config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 3.0.9
+- Adds support for Decimal and Float data types during writes to Cosmos DB.
+
+## 3.0.8
+- Fixes type cast exception when using "WriteThroughputBudget" config.
+
+## 3.0.7
+- Adds error information for bulk failures to exception and log.
+
+## 3.0.6
+- Fixes streaming checkpoint issues.
+
+## 3.0.5
+- Fixes log level of a message left unintentionally with level ERROR to reduce noise
+
+## 3.0.4
+- Fixes a bug in structured streaming during partition splits - possibly resulting in missing some change feed records or seeing Null exceptions for checkpoint writes
+
+## 3.0.3
+- Fixes a bug where a custom schema provided for readStream is ignored
+
+## 3.0.2
+- Fixes regression (unshaded JAR includes all shaded dependencies) which increased build time by 50%
+
+## 3.0.1
+- Fixes a dependency issue causing Direct Transport over TCP to fail with RequestTimeoutException
+
+## 3.0.0
+- Improves connection management and connection pooling to reduce number of metadata calls

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.0.8</version>
+    <version>3.1.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>
@@ -77,7 +77,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
@@ -167,7 +167,13 @@ object CosmosDBRowConverter extends RowConverter[Document]
       case IntegerType          => element.asInstanceOf[Int]
       case LongType             => element.asInstanceOf[Long]
       case FloatType            => element.asInstanceOf[Float]
-      case DecimalType()        => element.asInstanceOf[Decimal].toJavaBigDecimal
+      case DecimalType()        => if (element.isInstanceOf[Decimal]) {
+        element.asInstanceOf[Decimal].toJavaBigDecimal
+      } else if (element.isInstanceOf[java.lang.Long]) {
+        new java.math.BigDecimal(element.asInstanceOf[java.lang.Long])
+      } else {
+        element.asInstanceOf[java.math.BigDecimal]
+      }
       case StringType           =>
         if (isInternalRow) {
           new String(element.asInstanceOf[UTF8String].getBytes, "UTF-8")


### PR DESCRIPTION
### Adds support for bulk updates with nested partition keys
- Bulk updates with nested partition keys failed because the partition key definition was passed into the bulk updated stored procedure as "**parentNode/nestedPartitionKeyProperty**". The stored procedure uses the partition key definition to generate a sql query - so instead the definition should have been passed in as "**parentNode.nestedPartitionKeyProperty**". This fix is contained in the new version of the bulk executor library "_com.microsoft.azure:documentdb-bulkexecutor:2.11.0_"

### Adds support for Float and Decimal
- When using a data frame with a schema containing DecimalType() or FloatType an error similar to below happened when trying to write the data frame to CosmosDB - this has also been reported here: [#334](https://github.com/Azure/azure-cosmosdb-spark/issues/334)

`org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 4 times, most recent failure: Lost task 0.3 in stage 0.0 (TID 4, 10.139.64.4, executor 0):
 java.lang.RuntimeException: java.lang.Exception: Cannot cast 1.35 into a Json value. DecimalType(10,2) has no matching Json value.
	at cosmosdb_connector_shaded.rx.exceptions.Exceptions.propagate(Exceptions.java:57)
	at cosmosdb_connector_shaded.rx.observables.BlockingObservable.blockForSingle(BlockingObservable.java:463)
	at cosmosdb_connector_shaded.rx.observables.BlockingObservable.last(BlockingObservable.java:226)
	at org.apache.spark.sql.cosmosdb.util.StreamingWriteTask.importStreamingData(StreamingUtils.scala:87)
	at com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBSink$$anonfun$addBatch$4.apply(CosmosDBSink.scala:55)
	at com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBSink$$anonfun$addBatch$4.apply(CosmosDBSink.scala:53)
	at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$28.apply(RDD.scala:987)
	at org.apache.spark.rdd.RDD$$anonfun$foreachPartition$1$$anonfun$apply$28.apply(RDD.scala:987)
	at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2321)
	at org.apache.spark.SparkContext$$anonfun$runJob$5.apply(SparkContext.scala:2321)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.doRunTask(Task.scala:140)
	at org.apache.spark.scheduler.Task.run(Task.scala:113)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$17.apply(Executor.scala:606)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1541)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:612)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.Exception: Cannot cast 1.35 into a Json value. DecimalType(10,2) has no matching Json value.
	at com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter$.com$microsoft$azure$cosmosdb$spark$schema$CosmosDBRowConverter$$convertToJson(CosmosDBRowConverter.scala:186)
	at com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter$$anonfun$internalRowToJSONObject$1.apply(CosmosDBRowConverter.scala:156)
	at com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter$$anonfun$internalRowToJSONObject$1.apply(CosmosDBRowConverter.scala:154)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)`

- The lack of support for Float and Decimal was kind of intentional, because using these types can have unforseen consequences because different JSON Parsers/Libraries handle numeric floating point value very differently (rounding errors, different precision support etc.). So the usual guidance was (and is) to cast the columns to either String (for exact representation) or double (better interop). But the customer feedback has been clear - it is expected to be able to use floating point native values as a concise decision when customers are able to control the Json parsers etc. involved. So with this change ware going to add support for it.


### Adds support for TimestampType when using Long/Unix-Epoch-Style values
- The serialization of data frames failed when using a TimestampType in the schema for columns whose timestamp is represented as Long/Unix-Epoch-Style value. This has been reported here as well - [#303](https://github.com/Azure/azure-cosmosdb-spark/issues/303) - and seems to be a rather common issue when inserting data form an EventHub into Cosmos DB via the Spark connector. 
- The error that was thrown in this case looked similar to below:
`org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 20.0 failed 4 times, most recent failure: Lost task 0.3 in stage 20.0 (TID 50, 10.139.64.4, executor 0):
java.lang.ClassCastException: java.lang.Long cannot be cast to java.sql.Timestamp
	at com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter$.com$microsoft$azure$cosmosdb$spark$schema$CosmosDBRowConverter$$convertToJson(CosmosDBRowConverter.scala:175)
	at com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter$$anonfun$internalRowToJSONObject$1.apply(CosmosDBRowConverter.scala:156)
	at com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter$$anonfun$internalRowToJSONObject$1.apply(CosmosDBRowConverter.scala:154)
	at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	at com.microsoft.azure.cosmosdb.spark.schema.CosmosDBRowConverter$.internalRowToJSONObject(CosmosDBRowConverter.scala:154)
	at com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBWriteStreamRetryPolicy$$anonfun$2.apply(CosmosDBWriteStreamRetryPolicy.scala:92)
	at com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBWriteStreamRetryPolicy$$anonfun$2.apply(CosmosDBWriteStreamRetryPolicy.scala:90)
	at com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBWriteStreamRetryPolicyUtil.lambda$ProcessWithRetries$5(CosmosDBWriteStreamRetryPolicyUtil.java:57)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:69)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeFromIterable$IterableProducer.slowPath(OnSubscribeFromIterable.java:117)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeFromIterable$IterableProducer.request(OnSubscribeFromIterable.java:89)
	at cosmosdb_connector_shaded.rx.Subscriber.setProducer(Subscriber.java:211)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeMap$MapSubscriber.setProducer(OnSubscribeMap.java:102)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeFlattenIterable$OnSubscribeScalarFlattenIterable.call(OnSubscribeFlattenIterable.java:351)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeFlattenIterable$OnSubscribeScalarFlattenIterable.call(OnSubscribeFlattenIterable.java:321)
	at cosmosdb_connector_shaded.rx.Observable.unsafeSubscribe(Observable.java:10327)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:48)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeMap.call(OnSubscribeMap.java:33)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:48)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeLift.call(OnSubscribeLift.java:30)
	at cosmosdb_connector_shaded.rx.Observable.unsafeSubscribe(Observable.java:10327)
	at cosmosdb_connector_shaded.rx.internal.operators.DeferredScalarSubscriber.subscribeTo(DeferredScalarSubscriber.java:153)
	at cosmosdb_connector_shaded.rx.internal.operators.OnSubscribeReduceSeed.call(OnSubscribeReduceSeed.java:40)`
- With V3.1.0 using timestamps in the Long/Unix-Epoch-style representation is supported now. 