### PR TITLE
Streaming checkpoint edge case fix where in the "id" contains "|" character with the "ChangeFeedMaxPagesPerBatch" config applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.1
+- Fixes a streaming checkpoint edge case where in the "id" contains "|" character with the "ChangeFeedMaxPagesPerBatch" config applied
+
 ## 3.1.0
 - Adds support for bulk updates when using nested partition keys
 - Adds support for Decimal and Float data types during writes to Cosmos DB.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.0.8"
+  val currentVersion = "2.4.0_2.11-3.1.1"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -137,9 +137,16 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
     if (currentContinuation != null &&
       currentContinuation.contains("|")) {
       val continuationFragments = currentContinuation.split('|')
+      if (continuationFragments.size <= 2) {
+        lastProcessedIdBookmark = continuationFragments(1)
+      }
+      // handle the case in which "id" contains "|" character included in it
+      else {
+        lastProcessedIdBookmark = currentContinuation.substring(continuationFragments(0).length + 1)
+      }
       currentContinuation = continuationFragments(0)
       changeFeedOptions.setRequestContinuation(currentContinuation)
-      lastProcessedIdBookmark = continuationFragments(1)
+      logInfo(s"***** currentContinuation = ${currentContinuation} lastProcessedIdBookmark = ${lastProcessedIdBookmark} foundBookmark = ${foundBookmark}")
       foundBookmark = false
     }
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -146,7 +146,6 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
       }
       currentContinuation = continuationFragments(0)
       changeFeedOptions.setRequestContinuation(currentContinuation)
-      logInfo(s"***** currentContinuation = ${currentContinuation} lastProcessedIdBookmark = ${lastProcessedIdBookmark} foundBookmark = ${foundBookmark}")
       foundBookmark = false
     }
 


### PR DESCRIPTION
Description:

When the "ChangeFeedMaxPagesPerBatch" limit is reached during changefeed, the bookmarking is done in the format of "{token}|{Id}", where {id} is the id of the last processed doc for the given partition in a micro-batch. The written bookmark is in turn parsed in the next batch by splitting on "|" and matching the id with the id of the next set of changfeed records. 

If the "Id" contains "|" character in it, the it unintentionally gets split resulting in a non-match and loosing the remaining changefeed records for the given partition. 

Added the check on "continuationFragments.size" and if > 2, include all split-fragments except the continuation token in id. 