### PR TITLE
Adds a new config option "changefeedstartfromdatetime"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.3.0
-- Adds a new config option "changefeedstartfromdatetime" that can be used to specify from when the changefeed shoudl be processed. See [Config options](https://github.com/Azure/azure-cosmosdb-spark/wiki/Configuration-references) for details.
+- Adds a new config option "changefeedstartfromdatetime" that can be used to specify from when the changefeed should be processed. See [Config options](https://github.com/Azure/azure-cosmosdb-spark/wiki/Configuration-references) for details.
 
 ## 3.2.0
 - Fixes a regression that caused excessive memory consumption on the executors for large result sets (for example with millions of rows) ultimately resulting in an error "java.lang.OutOfMemoryError: GC overhead limit exceeded"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.0
+- Adds a new config option "changefeedstartfromdatetime" that can be used to specify from when the changefeed shoudl be processed. See [Config options](https://github.com/Azure/azure-cosmosdb-spark/wiki/Configuration-references) for details.
+
 ## 3.2.0
 - Fixes a regression that caused excessive memory consumption on the executors for large result sets (for example with millions of rows) ultimately resulting in an error "java.lang.OutOfMemoryError: GC overhead limit exceeded"
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.2.0</version>
+    <version>3.3.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>
@@ -51,7 +51,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-documentdb</artifactId>
-            <version>2.5.1</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnection.scala
@@ -134,7 +134,7 @@ private[spark] case class CosmosDBConnection(config: Config) extends CosmosDBLog
     val documentClient = CosmosDBConnectionCache.getOrCreateClient(clientConfig)
     val partitionId = changeFeedOptions.getPartitionKeyRangeId
 
-    logDebug(s"--> readChangeFeed, PageSize: ${changeFeedOptions.getPageSize.toString}, ContinuationToken: ${changeFeedOptions.getRequestContinuation}, PartitionId: $partitionId, ShouldInferSchema: ${shouldInferStreamSchema.toString}")
+    logDebug(s"--> readChangeFeed, PageSize: ${changeFeedOptions.getPageSize.toString}, ContinuationToken: ${changeFeedOptions.getRequestContinuation}, StartFromBeginning: ${changeFeedOptions.isStartFromBeginning}, StartDateTime: ${changeFeedOptions.getStartDateTime}, PartitionId: $partitionId, ShouldInferSchema: ${shouldInferStreamSchema.toString}")
 
     // The ChangeFeed API in the SDK allows accessing the continuation token
     // from the latest HTTP Response

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -70,6 +70,7 @@ object CosmosDBConfig {
   val ReadChangeFeed = "readchangefeed"
   val RollingChangeFeed = "rollingchangefeed"
   val ChangeFeedStartFromTheBeginning = "changefeedstartfromthebeginning"
+  val ChangeFeedStartFromDateTime = "changefeedstartfromdatetime"
   val ChangeFeedUseNextToken = "changefeedusenexttoken"
   val ChangeFeedContinuationToken = "changefeedcontinuationtoken"
   val ChangeFeedMaxPagesPerBatch = "changefeedmaxpagesperbatch"

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBSource.scala
@@ -69,7 +69,8 @@ private[spark] class CosmosDBSource(sqlContext: SQLContext,
         sqlContext.sparkSession.sparkContext.hadoopConfiguration).toMap, changeFeedCheckpointLocation)
 
       // Delete current tokens and next tokens checkpoint directories to ensure change feed starts from beginning if set
-      if (streamConfigMap.getOrElse(CosmosDBConfig.ChangeFeedStartFromTheBeginning, String.valueOf(false)).toBoolean) {
+      if (streamConfigMap.getOrElse(CosmosDBConfig.ChangeFeedStartFromTheBeginning, String.valueOf(false)).toBoolean ||
+         StringUtils.isNotBlank(streamConfigMap.getOrElse(CosmosDBConfig.ChangeFeedStartFromDateTime, ""))) {
         val queryName = Config(streamConfigMap)
           .get[String](CosmosDBConfig.ChangeFeedQueryName).get
         val currentTokensCheckpointPath = changeFeedCheckpointLocation + "/" + HdfsUtils.filterFilename(queryName)
@@ -87,6 +88,8 @@ private[spark] class CosmosDBSource(sqlContext: SQLContext,
       val helperDfConfig: Map[String, String] = streamConfigMap
         .-(CosmosDBConfig.ChangeFeedStartFromTheBeginning)
         .+((CosmosDBConfig.ChangeFeedStartFromTheBeginning, String.valueOf(false)))
+        .-(CosmosDBConfig.ChangeFeedStartFromDateTime).
+        +((CosmosDBConfig.ChangeFeedStartFromDateTime,null))
         .-(CosmosDBConfig.ReadChangeFeed).
         +((CosmosDBConfig.ReadChangeFeed, String.valueOf(false)))
         .-(CosmosDBConfig.QueryCustom).

--- a/src/test/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBDataFrameSpec.scala
+++ b/src/test/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBDataFrameSpec.scala
@@ -173,6 +173,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     verifyReadChangeFeed(
       rollingChangeFeed = false,
       startFromTheBeginning = true,
+      startFromDateTime = "",
       useNextToken = false,
       spark)
   }
@@ -181,6 +182,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     verifyReadChangeFeed(
       rollingChangeFeed = true,
       startFromTheBeginning = true,
+      startFromDateTime = "",
       useNextToken = false,
       spark)
   }
@@ -189,6 +191,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     verifyReadChangeFeed(
       rollingChangeFeed = false,
       startFromTheBeginning = false,
+      startFromDateTime = "",
       useNextToken = false,
       spark)
   }
@@ -197,6 +200,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     verifyReadChangeFeed(
       rollingChangeFeed = true,
       startFromTheBeginning = false,
+      startFromDateTime = "",
       useNextToken = false,
       spark)
   }
@@ -205,6 +209,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     verifyReadChangeFeed(
       rollingChangeFeed = false,
       startFromTheBeginning = true,
+      startFromDateTime = "",
       useNextToken = true,
       spark)
   }
@@ -214,6 +219,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
       verifyReadChangeFeed(
         rollingChangeFeed = false,
         startFromTheBeginning = false,
+        startFromDateTime = "",
         useNextToken = true,
         spark)
   }
@@ -228,6 +234,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
     */
   def verifyReadChangeFeed(rollingChangeFeed: Boolean,
                            startFromTheBeginning: Boolean,
+                           startFromDateTime: String,
                            useNextToken: Boolean,
                            spark: SparkSession): Unit = {
 
@@ -252,6 +259,7 @@ class CosmosDBDataFrameSpec extends RequiresCosmosDB {
       "ReadChangeFeed" -> "true",
       "ChangeFeedQueryName" -> s"$rollingChangeFeed $startFromTheBeginning $useNextToken",
       "ChangeFeedStartFromTheBeginning" -> startFromTheBeginning.toString,
+      "ChangeFeedStartFromDateTime" -> startFromDateTime,
       "ChangeFeedUseNextToken" -> useNextToken.toString,
       "RollingChangeFeed" -> rollingChangeFeed.toString,
       CosmosDBConfig.ChangeFeedCheckpointLocation -> checkpointPath,


### PR DESCRIPTION
Adds a new config option "changefeedstartfromdatetime" that can be used to specify from when the changefeed should be processed.

See [Config options](https://github.com/Azure/azure-cosmosdb-spark/wiki/Configuration-references) for details.