### PR TITLE
Fix to capture updates to existing docs when maxPagesPerBatch is used with streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 3.3.2
-- Fix to capture updates to existing docs when maxPagesPerBatch is used with streaming. 
+- Fixes an issue preventing updates to existing documents being captured in bookmarks when maxPagesPerBatch is used with streaming. 
 
 ### 3.3.1
 - Fixes null pointer exception in streaming schema inference. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.3.2
+- Fix to capture updates to existing docs when maxPagesPerBatch is used with streaming. 
+
 ### 3.3.1
 - Fixes null pointer exception in streaming schema inference. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.3.1"
+  val currentVersion = "2.4.0_2.11-3.3.2"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }


### PR DESCRIPTION
Problem:
- Do not capture updates to existing docs when maxPagesPerBatch is used with streaming

Details:
- The bookmark is in the format of "token | id" when maxPagesPerBatch is used with streaming where id is the id of the last processed doc. Newer change feed items including updated items are captured in the next batch using the extracted token from above. However, the newer docs are not added to the list until after the doc with the above "id" is found and so the updated docs are not added to the cfDocuments. 

Solution:

- Add the docs with _lsn > last-token to the list while searching for docs  with the last id. This will make sure that the updated docs are captured prior to capturing remaining docs in the block. 