### PR TITLE
Fix MapType issue in Streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.3.4
+- Fixes an issue in Streaming preventing docs with MapType to be ingested into Cosmos DB
+
 ### 3.3.3
 - Fixes an issue preventing apps from gracefully shutting down by moving Timer task in CosmosDBConnectionCache to a daemon thread
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.3.3</version>
+    <version>3.3.4</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.3.3"
+  val currentVersion = "2.4.0_2.11-3.3.4"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }


### PR DESCRIPTION
**Issue**:

Github Issue: https://github.com/Azure/azure-cosmosdb-spark/issues/355

Streaming writes to cosmos db fails if the schema has MapType fields 

Exception: UnsafeMapData cannot be cast to scala.collection.immutable.Map

**Details**:
The streaming path uses spark’s internal optimized-Map(UnsafeMapData) and cannot be directly casted to scala's Map

**Solution**:
Get the keyArray() & valueArray() from UnsafeMapData and zip them to scala's immutable Map which is then passed to mapTypeToJSONObject
