### PR TITLE
add support for option for preserving null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ### 3.3.5-SNAPSHOT
-- Fixed an issue in write causing NULL columns to not persisted in Cosmos DB.
-  Now columns with NULL values will be correctly presisted.
+- Added support for preserveNullInWrite option to preserve null values in write.
 
 ### 3.3.4
 - Fixes an issue in Streaming preventing docs with MapType to be ingested into Cosmos DB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.3.5
+### 3.3.5-SNAPSHOT
 - Fixed an issue in write causing NULL columns to not persisted in Cosmos DB.
   Now columns with NULL values will be correctly presisted.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.3.5
+- Fixed an issue in write causing NULL columns to not persisted in Cosmos DB.
+  Now columns with NULL values will be correctly presisted.
+
 ### 3.3.4
 - Fixes an issue in Streaming preventing docs with MapType to be ingested into Cosmos DB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.3.5-SNAPSHOT
+### 3.4.0
 - Added support for preserveNullInWrite option to preserve null values in write.
 
 ### 3.3.4

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.3.4</version>
+    <version>3.3.5-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.3.5-SNAPSHOT</version>
+    <version>3.4.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -102,6 +102,7 @@ object CosmosDBConfig {
   val Upsert = "upsert"
   val ClientInitDelay = "clientinitdelay"
   val RootPropertyToSave = "rootpropertytosave"
+  val PreserveNullInWrite = "preservenullinwrite"
 
   // Bulk executor library related
   val BulkImport = "bulkimport"
@@ -138,6 +139,7 @@ object CosmosDBConfig {
   val DefaultPageSize = 1000
   val DefaultSampleSize: Int = DefaultPageSize
   val DefaultUpsert = false
+  val DefaultPreserveNullInWrite = false
   val DefaultReadChangeFeed = false
   val DefaultStructuredStreaming = false
   val DefaultRollingChangeFeed = false

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRelation.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRelation.scala
@@ -40,6 +40,8 @@ class CosmosDBRelation(private val config: Config,
 
   implicit val _: Config = config
 
+  private val cosmosDBRowConverter = new CosmosDBRowConverter(SerializationConfig.fromConfig(config))
+
   // Take sample documents to infer the schema
   private lazy val lazySchema = {
     val sampleSize: Long = config.get[String](CosmosDBConfig.SampleSize)
@@ -75,7 +77,7 @@ class CosmosDBRelation(private val config: Config,
       requiredColumns = requiredColumns,
       filters = filters)
 
-    CosmosDBRowConverter.asRow(CosmosDBRelation.pruneSchema(schema, requiredColumns), rdd)
+    cosmosDBRowConverter.asRow(CosmosDBRelation.pruneSchema(schema, requiredColumns), rdd)
   }
 
   override def equals(other: Any): Boolean = other match {

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRelation.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRelation.scala
@@ -40,7 +40,7 @@ class CosmosDBRelation(private val config: Config,
 
   implicit val _: Config = config
 
-  private val cosmosDBRowConverter = new CosmosDBRowConverter(SerializationConfig.fromConfig(config))
+  @transient private val cosmosDBRowConverter = new CosmosDBRowConverter(SerializationConfig.fromConfig(config))
 
   // Take sample documents to infer the schema
   private lazy val lazySchema = {

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/schema/CosmosDBRowConverter.scala
@@ -144,8 +144,7 @@ object CosmosDBRowConverter extends RowConverter[Document]
   def rowToJSONObject(row: Row): JSONObject = {
     val jsonObject: JSONObject = new JSONObject()
     row.schema.fields.zipWithIndex.foreach({
-      case (field, i) if row.isNullAt(i) => if (field.dataType == NullType) jsonObject.remove(field.name)
-      case (field, i)                    => jsonObject.put(field.name, convertToJson(row.get(i), field.dataType, isInternalRow = false))
+      case (field, i) => jsonObject.put(field.name, convertToJson(row.get(i), field.dataType, isInternalRow = false))
     })
     jsonObject
   }
@@ -153,8 +152,7 @@ object CosmosDBRowConverter extends RowConverter[Document]
   def internalRowToJSONObject(internalRow: InternalRow, schema: StructType): JSONObject = {
     val jsonObject: JSONObject = new JSONObject()
     schema.fields.zipWithIndex.foreach({
-      case (field, i) if internalRow.isNullAt(i) => if (field.dataType == NullType) jsonObject.remove(field.name)
-      case (field, i)                    => jsonObject.put(field.name, convertToJson(internalRow.get(i, field.dataType), field.dataType, isInternalRow = true))
+      case (field, i) => jsonObject.put(field.name, convertToJson(internalRow.get(i, field.dataType), field.dataType, isInternalRow = true))
     })
     jsonObject
   }
@@ -168,6 +166,7 @@ object CosmosDBRowConverter extends RowConverter[Document]
       case IntegerType          => element.asInstanceOf[Int]
       case LongType             => element.asInstanceOf[Long]
       case FloatType            => element.asInstanceOf[Float]
+      case NullType             => JSONObject.NULL
       case DecimalType()        => if (element.isInstanceOf[Decimal]) {
         element.asInstanceOf[Decimal].toJavaBigDecimal
       } else if (element.isInstanceOf[java.lang.Long]) {


### PR DESCRIPTION
prior to this PR null value in the data was dropped in write. This PR adds support for option `preserveNullInWrite` to preserve null values.
The default is false to keep the old behaviour by default.

if we read data with null value columns from source container when writing to dest container we should support preserving null values.

This addresses this ICM: https://portal.microsofticm.com/imp/v3/incidents/details/211857363/home
```scala
val srCFG = Map("Endpoint" -> "https://test.documents.azure.com:443/",
  "Masterkey" -> "XYZ",
  "Database" -> "testdb",
  "Collection" -> "srccol")

val destCfg = Map("Endpoint" -> "https:/test.documents.azure.com:443/",
  "Masterkey" -> "XYZ",
  "Database" -> "testdb",
  "Collection" -> "testcol",
  "upsert" -> "true",
  "preserveNullInWrite" -> "true"
)

val spark = SparkSession.builder()
  .appName("spark connector sample")
  .master("local")
  .getOrCreate()


val df = spark.read
  .format("com.microsoft.azure.cosmosdb.spark")
  .options {
    srCFG
  }
  .load()

df.write.format("com.microsoft.azure.cosmosdb.spark").mode("append").options {
  destCfg
}.save()
```