### PR TITLE
Improved Write Throughput Budget to limit the RU consumption during bulk operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.5.0
+- Improves Write Throughput Budget accuracy that can be used to limit the RU consumption during bulk operations
+
 ### 3.4.0
 - Added support for preserveNullInWrite option to preserve null values in write.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.5.0
+### 3.4.1
 - Improves Write Throughput Budget accuracy that can be used to limit the RU consumption during bulk operations
 
 ### 3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
-### 3.4.1
-- Improves Write Throughput Budget accuracy that can be used to limit the RU consumption during bulk operations
-
 ### 3.4.0
 - Added support for preserveNullInWrite option to preserve null values in write.
+- Improves Write Throughput Budget accuracy that can be used to limit the RU consumption during bulk operations
 
 ### 3.3.4
 - Fixes an issue in Streaming preventing docs with MapType to be ingested into Cosmos DB

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.4.0</version>
+    <version>3.4.1</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>
@@ -77,7 +77,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.11.0</version>
+            <version>2.11.1</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.4.1</version>
+    <version>3.4.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ limitations under the License.
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>documentdb-bulkexecutor</artifactId>
-            <version>2.11.1</version>
+            <version>2.12.0</version>
             <exclusions>
               <exclusion>
                 <groupId>com.microsoft.azure</groupId>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/BulkExecutorSettings.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/BulkExecutorSettings.scala
@@ -27,16 +27,9 @@ package com.microsoft.azure.cosmosdb.spark
   *
   * @param maxMiniBatchUpdateCount         specifies the maximum count of update items in a mini-batch
   *                                        used in bulk import API. Default value is 500
-  * @param maxMiniBatchImportSizeKB        specifies the max mini-batch size (specific to bulk import API) i bytes.
-  *                                        Default value is 220200
-  * @param maxThroughputForBulkOperations  specifies the throughput allocated for bulk operations out of the
-  *                                        collection's total throughput (optional). If not specified the entire
-  *                                        provisioned throughput for the container can be used for bulk operations
   * @param partitionKeyOption              Can be used to specify the partition key (optional). If not specified the
   *                                        partition key definition is retrieved at runtime for the target container
   */
 private[spark] case class BulkExecutorSettings(
                                  maxMiniBatchUpdateCount: Int,
-                                 maxMiniBatchImportSizeKB: Int,
-                                 maxThroughputForBulkOperations: Option[Int],
                                  partitionKeyOption: Option[String])

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/ClientConfiguration.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/ClientConfiguration.scala
@@ -107,28 +107,11 @@ object ClientConfiguration extends CosmosDBLoggingTrait {
 
   private def createBulkExecutorSettings(config: Config) : BulkExecutorSettings = {
     val pkDef: Option[String] = config.get[String](CosmosDBConfig.PartitionKeyDefinition)
-    val maxMiniBatchImportSizeKB: Int = config
-      .getOrElse(CosmosDBConfig.MaxMiniBatchImportSizeKB, CosmosDBConfig.DefaultMaxMiniBatchImportSizeKB)
     val maxMiniBatchUpdateCount: Int = config
       .getOrElse(CosmosDBConfig.MaxMiniBatchUpdateCount, CosmosDBConfig.DefaultMaxMiniBatchUpdateCount)
-    val maxThroughputForBulkOperationsValue: Option[String] =  config
-      .get(CosmosDBConfig.WriteThroughputBudget)
-    val maxThroughputForBulkOperations: Option[Int] = 
-      if (maxThroughputForBulkOperationsValue.isDefined) {
-        val maxThroughputForBulkOperationsValue : String = config.get(CosmosDBConfig.WriteThroughputBudget).get
-        if (maxThroughputForBulkOperationsValue.trim.length > 0) {
-          Some(maxThroughputForBulkOperationsValue.toInt)
-        } else {
-          None
-        }
-      } else {
-        None
-      }
 
     BulkExecutorSettings(
       maxMiniBatchUpdateCount,
-      maxMiniBatchImportSizeKB,
-      maxThroughputForBulkOperations,
       pkDef)
   }
 

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.4.1"
+  val currentVersion = "2.4.0_2.11-3.4.0"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.3.4"
+  val currentVersion = "2.4.0_2.11-3.4.1"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnectionCache.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnectionCache.scala
@@ -96,17 +96,8 @@ object CosmosDBConnectionCache extends CosmosDBLoggingTrait {
     } else {
       val client: DocumentClient = clientCacheEntry.docClient
       val pkDef = getPartitionKeyDefinition(config)
-      val maxAvailableThroughput = getOrReadMaxAvailableThroughput(config)
 
-      val effectivelyAvailableThroughputForBulkOperations =
-        if (config.bulkConfig.maxThroughputForBulkOperations.isDefined) {
-          Math.min(
-            config.bulkConfig.maxThroughputForBulkOperations.get,
-            maxAvailableThroughput
-          )
-        } else {
-          maxAvailableThroughput
-        }
+      val effectivelyAvailableThroughputForBulkOperations = getOrReadMaxAvailableThroughput(config)
 
       val builder = DocumentBulkExecutor.builder
         .from(
@@ -118,7 +109,6 @@ object CosmosDBConnectionCache extends CosmosDBLoggingTrait {
         )
         .withInitializationRetryOptions(bulkExecutorInitializationRetryOptions)
         .withMaxUpdateMiniBatchCount(config.bulkConfig.maxMiniBatchUpdateCount)
-        .withMaxMiniBatchSize(config.bulkConfig.maxMiniBatchImportSizeKB * 1024)
 
       // Instantiate DocumentBulkExecutor
       val bulkExecutor = builder.build()

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -113,6 +113,8 @@ object CosmosDBConfig {
   val WriteThroughputBudget = "writethroughputbudget"
   val BulkImportMaxConcurrencyPerPartitionRange = "bulkimport_maxconcurrencyperpartitionrange"
   val MaxMiniBatchImportSizeKB = "maxminibatchimportsizekb"
+  val BaseMiniBatchRUConsumption = "baseminibatchruconsumption"
+  val MaxIngestionTaskParallelism = "maxingestiontaskparallelism"
 
   // Rx Java related write config
   val WritingBatchDelayMs = "writingbatchdelayms"
@@ -173,6 +175,8 @@ object CosmosDBConfig {
   val DefaultMaxMiniBatchImportSizeKB = 100
 
   val DefaultBulkImportMaxConcurrencyPerPartitionRange = 1
+
+  val DefaultBaseMiniBatchRUConsumption = 2000
 
   def parseParameters(parameters: Map[String, String]): Map[String, Any] = {
     parameters.map { case (x, v) => x -> v }


### PR DESCRIPTION
**Purpose**:
Limit the RU consumption during bulk operations with OLTP Spark connector, so that 
•	available RUs on the container / database can be shared across processes by reserving only a given % of RUs for bulk operations
•	minimize throttling during bulk operations there by reducing the overhead of retries

**Context**:
The spark dataframe that is used for bulk operations can have one or more spark partitions and determines the number of parallel spark tasks to import the documents to cosmos db container. The documents in each spark partition are in turn split across the cosmos db physical partitions based on the hash value of the defined partition key. The documents corresponding to each cosmos db physical partition are bucketed into minibatches and imported in parallel by the underlying spark tasks. In summary, **each** spark partition / task ingests into **all** cosmos db physical partitions in parallel at any given point of time, with a given fairly equally distributed dataset. 

**Details**:
The 2 levers that are used to limit the RU consumption are 
•	Mini Batch size
•	Sleep duration between mini batch imports

Below are the high level steps that are being used to dynamically control the above 2 levers during each minibatch import, so as to align the total RU consumption with the provided WriteThroughputBudget. 
•	An initial general case mini batch size is calculated based on the provided writeThroughputBudget, # of spark partitions and the baseRUConsumption

•	An initial one-time bulk import is performed with this batch size and the RU consumption for the above batch import is collected. The collected RU consumption will take into consideration the indexed vs non-indexed target container, size of the imported docs etc: 

•	A miniBatchSizeAdjustmentFactor is calculated based on the above RU consumption and the minibatch size is adjusted based on this. 

•	Based on the Elapsed time and the consumed RU for each batch import, a sleep duration is calculated to limit the RU consumption per second and is used to pause the thread prior to the next batch import. 

A new config “maxIngestionTaskParallelism” is added that may be used in rare BulkImport cases where there is not enough cores available on spark cluster as there are spark partitions. For eg:, if the ingestion DF has 100 spark partitions and the spark cluster has only 32 cores there by limiting it to have max parallelism of 32 spark tasks, then “maxIngestionTaskParallelism” can be set to 32 for the calculations to take into account the max number of parallel tasks.  

**Experiments**:
Testing has been performed against indexed / non-indexed, manual / auto-scale containers with varying # of spark partitions, # of cosmos db partitions and the actual RU consumption have been in the **+/- 10% ranges** of the provided WriteThroughputRUBudget. 
