### PR TITLE
Config to enable converting nested docs that are derived as string to the native jason format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 3.6.3
-- Adds a boolean config to enable converting nested docs that are derived as string into the native jason format  
+- Adds a boolean config to enable converting nested docs that are derived as string into the native json format  
 
 ### 3.6.2
 - Fixes an issue sometimes resulting in unnecessary duplucates when using readStream in combination with maxPagesPerBacth setting and updating documents  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.4.1
+- Fixes a regression preventing docs with MapType and of type NonInternalRow to be ingested in Batch mode to Cosmos DB 
+
 ### 3.4.0
 - Added support for preserveNullInWrite option to preserve null values in write.
 - Improves Write Throughput Budget accuracy that can be used to limit the RU consumption during bulk operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.6.3
+- Adds a boolean config to enable converting nested docs that are derived as string into the native jason format  
+
 ### 3.6.2
 - Fixes an issue sometimes resulting in unnecessary duplucates when using readStream in combination with maxPagesPerBacth setting and updating documents  
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.6.0</version>
+    <version>3.6.1</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.6.2</version>
+    <version>3.6.3</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.4.0</version>
+    <version>3.4.1</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.4.0"
+  val currentVersion = "2.4.0_2.11-3.4.1"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.6.2"
+  val currentVersion = "2.4.0_2.11-3.6.3"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.6.0"
+  val currentVersion = "2.4.0_2.11-3.6.1"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -65,6 +65,7 @@ object CosmosDBConfig {
   val QueryDisableRUPerMinuteUsage = "query_disableruperminuteusage"
   val QueryEmitVerboseTraces = "query_emitverbosetraces"
   val ResponseContinuationTokenLimitInKb = "response_continuationtoken_limit_kb"
+  val ConvertNestedDocsToNativeJsonFormat = "convertnesteddocstonativejsonformat"
 
   // Change feed streaming related
   val ReadChangeFeed = "readchangefeed"
@@ -177,6 +178,8 @@ object CosmosDBConfig {
   val DefaultBulkImportMaxConcurrencyPerPartitionRange = 1
 
   val DefaultBaseMiniBatchRUConsumption = 2000
+
+  val  DefaultConvertNestedDocsToNativeJsonFormat = false
 
   def parseParameters(parameters: Map[String, String]): Map[String, Any] = {
     parameters.map { case (x, v) => x -> v }


### PR DESCRIPTION
The nested fields in doc such as {key1: value1, key2: {key21: value21, key22: value22}} that are derived as string since they could be of different data types, get converted to {key1: value1, key2: {key21 = value21, key22 = value22}} when written out as parquet. The  hive json parser functions such as "get_json_object" is not able to parse this and needs to be in standard json format. 

Added the boolean config "ConvertNestedDocsToNativeJsonFormat" with default of false to enable this. 