### PR TITLE
Fixes NullPointerException during writeStream and Resource Not Found error when dropping and recreating containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 3.6.4
-- Fixes a regression introduced in 3.4.0 casuing NullPointerException during writeStream 
+- Fixes a regression introduced in 3.4.0 causing NullPointerException during writeStream 
 
 ### 3.6.3
 - Adds a boolean config to enable converting nested docs that are derived as string into the native json format  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.6.4
+- Fixes a regression introduced in 3.4.0 casuing NullPointerException during writeStream 
+
 ### 3.6.3
 - Adds a boolean config to enable converting nested docs that are derived as string into the native json format  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 3.6.4
 - Fixes a regression introduced in 3.4.0 causing NullPointerException during writeStream 
+- Adds a check to purge the Connection Cache when a Container is not available anymore (due to being dropped and recreated for example)
 
 ### 3.6.3
 - Adds a boolean config to enable converting nested docs that are derived as string into the native json format  

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.6.3</version>
+    <version>3.6.4</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.6.3"
+  val currentVersion = "2.4.0_2.11-3.6.4"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnectionCache.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnectionCache.scala
@@ -89,6 +89,17 @@ object CosmosDBConnectionCache extends CosmosDBLoggingTrait {
 
   startRefreshTimer()
 
+  def purgeCache(config: ClientConfiguration) : Unit = {
+    /**
+    * Resets the Connection Cache - this will be triggered if the container
+    * cannot be found - which might happen after deleting/re-creating the container
+    * with the same name
+    *
+    * @param config The cache key - represents the config settings
+    */
+    clientCache.remove(config)
+  }
+
   def getOrCreateBulkExecutor(config: ClientConfiguration): DocumentBulkExecutor = {
     val clientCacheEntry = getOrCreateClientCacheEntry(config)
     if (clientCacheEntry.bulkExecutor.isDefined) {


### PR DESCRIPTION
- Fixes a regression introduced in 3.4.0 causing NullPointerException during writeStream 
- Adds a check to purge the Connection Cache when a Container is not available anymore (due to being dropped and recreated for example)