### PR TITLE
Add logic to handle EOF exception in Streaming checkpoint reads caused by the transient Write flush exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 3.6.7
 - Fixes a bug introduced in 3.6.6 in the retry policy on collection recreation
+- Adds the logic to handle EOF exception in Streaming checkpoint reads caused by the transient flush exception during checkpoint writes
 
 ### 3.6.6
 - Adds a check to purge the Connection Cache when a Container is not available anymore (due to being dropped and recreated for example) during read operations

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -345,7 +345,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         )
       }
 
-//      initializeToken()
+      initializeToken()
 
       val startFromTheBeginning: Boolean = config
         .get[String](CosmosDBConfig.ChangeFeedStartFromTheBeginning)

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -1,25 +1,25 @@
 /**
-  * The MIT License (MIT)
-  * Copyright (c) 2016 Microsoft Corporation
-  *
-  * Permission is hereby granted, free of charge, to any person obtaining a copy
-  * of this software and associated documentation files (the "Software"), to deal
-  * in the Software without restriction, including without limitation the rights
-  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  * copies of the Software, and to permit persons to whom the Software is
-  * furnished to do so, subject to the following conditions:
-  *
-  * The above copyright notice and this permission notice shall be included in all
-  * copies or substantial portions of the Software.
-  *
-  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  * SOFTWARE.
-  */
+ * The MIT License (MIT)
+ * Copyright (c) 2016 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.microsoft.azure.cosmosdb.spark.rdd
 
 import java.util
@@ -65,19 +65,19 @@ object CosmosDBRDDIterator {
   }
 
   /**
-    * Get the path to the next continuation token
-    * @param queryName name of the query
-    * @return
-    */
+   * Get the path to the next continuation token
+   * @param queryName name of the query
+   * @return
+   */
   def getNextTokenPath(queryName: String): String = {
     queryName + queryName.hashCode + queryName.hashCode.hashCode()
   }
 
   /**
-    * Get the next global continuation token for the collection in the provided config
-    * @param config a structured stream configuration with connection details, a query name and a collection name
-    * @return       the corresponding global continuation token
-    */
+   * Get the next global continuation token for the collection in the provided config
+   * @param config a structured stream configuration with connection details, a query name and a collection name
+   * @return       the corresponding global continuation token
+   */
   def getCollectionTokens(config: Config, shouldGetCurrentToken: Boolean = false): String = {
     val connection = CosmosDBConnection(config)
     val collectionLink = connection.getCollectionLink
@@ -94,6 +94,7 @@ object CosmosDBRDDIterator {
       nextTokenMap = CosmosDBRDDIterator.hdfsUtils.readChangeFeedToken(
         changeFeedCheckpointLocation,
         if (shouldGetCurrentToken) queryName else getNextTokenPath(queryName),
+        if (shouldGetCurrentToken) getNextTokenPath(queryName) else queryName,
         collectionLink)
     }
 
@@ -120,8 +121,8 @@ object CosmosDBRDDIterator {
   }
 
   /**
-    * Used for verification purpose only. Clear the next continuation tokens cache to simulate a fresh start.
-    */
+   * Used for verification purpose only. Clear the next continuation tokens cache to simulate a fresh start.
+   */
   def resetCollectionContinuationTokens(): Any = {
     // no op
   }
@@ -169,8 +170,8 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
       .toInt
 
     /**
-      * Query documents from CosmosDB
-      */
+     * Query documents from CosmosDB
+     */
     def queryDocuments: Iterator[Document] = {
       val feedOpts = new FeedOptions()
       feedOpts.setPageSize(pageSize)
@@ -225,8 +226,8 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
     }
 
     /**
-      * Read documents change feed
-      */
+     * Read documents change feed
+     */
     def readChangeFeed: Iterator[Document] = {
 
       val objectMapper: ObjectMapper = new ObjectMapper()
@@ -253,12 +254,14 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         cfCurrentToken = CosmosDBRDDIterator.hdfsUtils.readChangeFeedTokenPartition(
           changeFeedCheckpointLocation,
           queryName,
+          CosmosDBRDDIterator.getNextTokenPath(queryName),
           collectionLink,
           partitionId)
 
         cfNextToken = CosmosDBRDDIterator.hdfsUtils.readChangeFeedTokenPartition(
           changeFeedCheckpointLocation,
           CosmosDBRDDIterator.getNextTokenPath(queryName),
+          queryName,
           collectionLink,
           partitionId)
 
@@ -266,6 +269,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
           cfCurrentToken = CosmosDBRDDIterator.hdfsUtils.readChangeFeedTokenPartition(
             changeFeedCheckpointLocation,
             queryName,
+            CosmosDBRDDIterator.getNextTokenPath(queryName),
             collectionLink,
             parentPartitionId)
         }
@@ -274,10 +278,11 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
           cfNextToken = CosmosDBRDDIterator.hdfsUtils.readChangeFeedTokenPartition(
             changeFeedCheckpointLocation,
             CosmosDBRDDIterator.getNextTokenPath(queryName),
+            queryName,
             collectionLink,
             parentPartitionId)
         }
-     }
+      }
 
       // Get continuation token for the partition with provided partitionId
       def getContinuationToken(partitionId: String): String = {
@@ -340,13 +345,13 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         )
       }
 
-      initializeToken()
+      //      initializeToken()
 
       val startFromTheBeginning: Boolean = config
         .get[String](CosmosDBConfig.ChangeFeedStartFromTheBeginning)
         .getOrElse(CosmosDBConfig.DefaultChangeFeedStartFromTheBeginning.toString)
         .toBoolean
-      
+
       val startFromDateTime: String = config
         .getOrElse[String](CosmosDBConfig.ChangeFeedStartFromDateTime, "")
 
@@ -359,7 +364,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         val startFromDateTimeParsed = CosmosDBRDDIterator.formatterGMT.parseDateTime(startFromDateTime);
         changeFeedOptions.setStartDateTime(startFromDateTimeParsed)
       }
-      
+
       if (currentToken != null && !currentToken.isEmpty) {
         changeFeedOptions.setRequestContinuation(currentToken)
       }
@@ -454,11 +459,11 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
       || exception.getSubStatusCode == SubStatusCodes.COMPLETING_SPLIT)
     {
       val retryDelayInMs = rnd.nextInt(1000)
-                
+
       logWarning(
         s"STREAMING EXCEPTION: Partition ${partition.partitionKeyRangeId} is splitting, " +
-        s"status code ${exception.getStatusCode}, subStatus ${exception.getSubStatusCode} " +
-        s"Retry delay (ms): $retryDelayInMs")
+          s"status code ${exception.getStatusCode}, subStatus ${exception.getSubStatusCode} " +
+          s"Retry delay (ms): $retryDelayInMs")
       Thread.sleep(retryDelayInMs)
       connection.reinitializeClient()
     } else {

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/rdd/CosmosDBRDDIterator.scala
@@ -1,25 +1,25 @@
 /**
- * The MIT License (MIT)
- * Copyright (c) 2016 Microsoft Corporation
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
 package com.microsoft.azure.cosmosdb.spark.rdd
 
 import java.util
@@ -65,19 +65,19 @@ object CosmosDBRDDIterator {
   }
 
   /**
-   * Get the path to the next continuation token
-   * @param queryName name of the query
-   * @return
-   */
+    * Get the path to the next continuation token
+    * @param queryName name of the query
+    * @return
+    */
   def getNextTokenPath(queryName: String): String = {
     queryName + queryName.hashCode + queryName.hashCode.hashCode()
   }
 
   /**
-   * Get the next global continuation token for the collection in the provided config
-   * @param config a structured stream configuration with connection details, a query name and a collection name
-   * @return       the corresponding global continuation token
-   */
+    * Get the next global continuation token for the collection in the provided config
+    * @param config a structured stream configuration with connection details, a query name and a collection name
+    * @return       the corresponding global continuation token
+    */
   def getCollectionTokens(config: Config, shouldGetCurrentToken: Boolean = false): String = {
     val connection = CosmosDBConnection(config)
     val collectionLink = connection.getCollectionLink
@@ -121,8 +121,8 @@ object CosmosDBRDDIterator {
   }
 
   /**
-   * Used for verification purpose only. Clear the next continuation tokens cache to simulate a fresh start.
-   */
+    * Used for verification purpose only. Clear the next continuation tokens cache to simulate a fresh start.
+    */
   def resetCollectionContinuationTokens(): Any = {
     // no op
   }
@@ -170,8 +170,8 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
       .toInt
 
     /**
-     * Query documents from CosmosDB
-     */
+      * Query documents from CosmosDB
+      */
     def queryDocuments: Iterator[Document] = {
       val feedOpts = new FeedOptions()
       feedOpts.setPageSize(pageSize)
@@ -226,8 +226,8 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
     }
 
     /**
-     * Read documents change feed
-     */
+      * Read documents change feed
+      */
     def readChangeFeed: Iterator[Document] = {
 
       val objectMapper: ObjectMapper = new ObjectMapper()
@@ -282,7 +282,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
             collectionLink,
             parentPartitionId)
         }
-      }
+     }
 
       // Get continuation token for the partition with provided partitionId
       def getContinuationToken(partitionId: String): String = {
@@ -345,7 +345,7 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
         )
       }
 
-      //      initializeToken()
+//      initializeToken()
 
       val startFromTheBeginning: Boolean = config
         .get[String](CosmosDBConfig.ChangeFeedStartFromTheBeginning)
@@ -462,8 +462,8 @@ class CosmosDBRDDIterator(hadoopConfig: mutable.Map[String, String],
 
       logWarning(
         s"STREAMING EXCEPTION: Partition ${partition.partitionKeyRangeId} is splitting, " +
-          s"status code ${exception.getStatusCode}, subStatus ${exception.getSubStatusCode} " +
-          s"Retry delay (ms): $retryDelayInMs")
+        s"status code ${exception.getStatusCode}, subStatus ${exception.getSubStatusCode} " +
+        s"Retry delay (ms): $retryDelayInMs")
       Thread.sleep(retryDelayInMs)
       connection.reinitializeClient()
     } else {

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/HdfsUtils.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/HdfsUtils.scala
@@ -1,25 +1,25 @@
 /**
- * The MIT License (MIT)
- * Copyright (c) 2016 Microsoft Corporation
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+  * The MIT License (MIT)
+  * Copyright (c) 2016 Microsoft Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all
+  * copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  */
 package com.microsoft.azure.cosmosdb.spark.util
 
 import java.io.{FileNotFoundException, PrintWriter, StringWriter}
@@ -58,7 +58,6 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
     val path = new Path(base + "/" + filePath)
     read(path, base, alternateQueryName, collectionRid)
   }
-
 
   def read(path: Path, location: String, alternateQueryName: String, collectionRid: String): String = {
     try {
@@ -164,11 +163,11 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
 object HdfsUtils {
 
   /**
-   * Get a map from Hadoop Configuration to use in persisting and reading from Hdfs file system
-   * The Hadoop Configuration is not serializable
-   * @param hadoopConfiguration  the hadoop configuration
-   * @return                     a map of configuration values
-   */
+    * Get a map from Hadoop Configuration to use in persisting and reading from Hdfs file system
+    * The Hadoop Configuration is not serializable
+    * @param hadoopConfiguration  the hadoop configuration
+    * @return                     a map of configuration values
+    */
   def getConfigurationMap(hadoopConfiguration: Configuration): mutable.Map[String, String] = {
     val configMap = mutable.Map[String, String]()
     val iterator = hadoopConfiguration.iterator()

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/HdfsUtils.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/util/HdfsUtils.scala
@@ -1,25 +1,25 @@
 /**
-  * The MIT License (MIT)
-  * Copyright (c) 2016 Microsoft Corporation
-  *
-  * Permission is hereby granted, free of charge, to any person obtaining a copy
-  * of this software and associated documentation files (the "Software"), to deal
-  * in the Software without restriction, including without limitation the rights
-  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  * copies of the Software, and to permit persons to whom the Software is
-  * furnished to do so, subject to the following conditions:
-  *
-  * The above copyright notice and this permission notice shall be included in all
-  * copies or substantial portions of the Software.
-  *
-  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  * SOFTWARE.
-  */
+ * The MIT License (MIT)
+ * Copyright (c) 2016 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.microsoft.azure.cosmosdb.spark.util
 
 import java.io.{FileNotFoundException, PrintWriter, StringWriter}
@@ -40,7 +40,7 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
     config
   }
 
-  private val maxRetryCount = 10
+  private val maxRetryCount = 50
   private val fs = FileSystem.get(new URI(changeFeedCheckpointLocation), fsConfig)
 
   def write(base: String, filePath: String, content: String): Unit = {
@@ -54,17 +54,34 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
     }
   }
 
-  def read(base: String, filePath: String): String = {
+  def read(base: String, filePath: String, alternateQueryName: String, collectionRid: String): String = {
     val path = new Path(base + "/" + filePath)
-    read(path)
+    read(path, base, alternateQueryName, collectionRid)
   }
 
-  def read(path: Path): String = {
-    retry(maxRetryCount) {
-      val os = fs.open(path)
-      val content = os.readUTF().replaceAll("\"", StringUtils.EMPTY)
-      os.close()
-      content
+
+  def read(path: Path, location: String, alternateQueryName: String, collectionRid: String): String = {
+    try {
+      retry(maxRetryCount) {
+        val os = fs.open(path)
+        val content = os.readUTF().replaceAll("\"", StringUtils.EMPTY)
+        os.close()
+        content
+      }
+    } catch {
+      case _: Throwable =>
+        // To handle transient flush exception after the write to checkpoint file
+        val alternateQueryNameAlphaNum = HdfsUtils.filterFilename(alternateQueryName)
+        val alternateSubPath = s"$alternateQueryNameAlphaNum/$collectionRid/${path.getName}"
+        val alternatePath = s"$location/$alternateSubPath"
+        if (fileExist(location, alternateSubPath)) {
+          val os = fs.open(new Path(alternatePath))
+          val content = os.readUTF().replaceAll("\"", StringUtils.EMPTY)
+          logInfo(s"Fallback Read of checkpoint File - $alternatePath with size = ${content.trim.size}")
+          content
+        } else {
+          StringUtils.EMPTY
+        }
     }
   }
 
@@ -99,12 +116,13 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
 
   def readChangeFeedTokenPartition(location: String,
                                    queryName: String,
+                                   alternateQueryName: String,
                                    collectionRid: String,
                                    partitionId: String): String = {
     val queryNameAlphaNum = HdfsUtils.filterFilename(queryName)
     val path = s"$queryNameAlphaNum/$collectionRid/$partitionId"
     if (fileExist(location, path)) {
-      read(location, path)
+      read(location, path, alternateQueryName, collectionRid)
     } else {
       StringUtils.EMPTY
     }
@@ -112,6 +130,7 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
 
   def readChangeFeedToken(location: String,
                           queryName: String,
+                          alternateQueryName: String,
                           collectionRid: String): java.util.HashMap[String, String] = {
     val queryNameAlphaNum = HdfsUtils.filterFilename(queryName)
     val path = s"$queryNameAlphaNum/$collectionRid"
@@ -120,7 +139,7 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
     if (files != null) {
       while (files.hasNext) {
         val file = files.next()
-        val token = read(file.getPath)
+        val token = read(file.getPath, location, alternateQueryName, collectionRid)
         tokens.put(file.getPath.getName, token)
       }
     }
@@ -132,6 +151,7 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
       fn
     } catch {
       case e if n > 1 => {
+        Thread.sleep(100)
         val sw = new StringWriter
         e.printStackTrace(new PrintWriter(sw))
         logError(s"Exception during executing HDFS operation with message: ${e.getMessage} and stacktrace: ${sw.toString}, retrying .. ")
@@ -144,11 +164,11 @@ case class HdfsUtils(configMap: Map[String, String], changeFeedCheckpointLocatio
 object HdfsUtils {
 
   /**
-    * Get a map from Hadoop Configuration to use in persisting and reading from Hdfs file system
-    * The Hadoop Configuration is not serializable
-    * @param hadoopConfiguration  the hadoop configuration
-    * @return                     a map of configuration values
-    */
+   * Get a map from Hadoop Configuration to use in persisting and reading from Hdfs file system
+   * The Hadoop Configuration is not serializable
+   * @param hadoopConfiguration  the hadoop configuration
+   * @return                     a map of configuration values
+   */
   def getConfigurationMap(hadoopConfiguration: Configuration): mutable.Map[String, String] = {
     val configMap = mutable.Map[String, String]()
     val iterator = hadoopConfiguration.iterator()


### PR DESCRIPTION
When WASB is used to store streaming checkpoint files, there rarely occurs an exception during flush() after the write of a valid token and during the close of the checkpoint file. In this case, the written token value is actually there, but until the block list is successfully flushed, it is not readable and we get the EOF exception for reads during this time. 

This PR increases the retrycount of checkpoint file reads and introduces a short 100 millisecond sleep between retries if the above issue occurs in checkpoint Reads. We see that in most of the cases, the flush issue recovers in few retries and so this should ideally take care of the issue. If still not recoverable, will fallback to the backup tokens location for the next tokens location read and vice versa.
