### PR TITLE
Reduces the performance overhead when a Spark DataFrame as many partitions - especially when using  Cosmos DB as a sink in Spark Streaming scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.6.8
+- Reduces the performance overhead when a Spark DataFrame as many partitions - especially when using  Cosmos DB as a sink in Spark Streaming scenarios
+
 ### 3.6.7
 - Fixes a bug introduced in 3.6.6 in the retry policy on collection recreation
 - Adds the logic to handle EOF exception in Streaming checkpoint reads caused by the transient flush exception during checkpoint writes

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.6.7</version>
+    <version>3.6.8</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/Constants.scala
@@ -23,6 +23,6 @@
 package com.microsoft.azure.cosmosdb.spark
 
 object Constants {
-  val currentVersion = "2.4.0_2.11-3.6.7"
+  val currentVersion = "2.4.0_2.11-3.6.8"
   val userAgentSuffix = s" SparkConnector/$currentVersion"
 }

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnectionCache.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBConnectionCache.scala
@@ -90,7 +90,7 @@ object CosmosDBConnectionCache extends CosmosDBLoggingTrait {
   startRefreshTimer()
 
   def purgeCache(config: ClientConfiguration) : Unit = {
-    /**
+    /*
     * Resets the Connection Cache - this will be triggered if the container
     * cannot be found - which might happen after deleting/re-creating the container
     * with the same name

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/CosmosDBSpark.scala
@@ -470,21 +470,10 @@ object CosmosDBSpark extends CosmosDBLoggingTrait {
     val isBulkUpdating = config.get[String](CosmosDBConfig.BulkUpdate).
       getOrElse(CosmosDBConfig.DefaultBulkUpdate.toString).
       toBoolean
-    val clientInitDelay = config.get[String](CosmosDBConfig.ClientInitDelay).
-      getOrElse(CosmosDBConfig.DefaultClientInitDelay.toString).
-      toInt
 
     val maxConcurrencyPerPartitionRange = config
       .getOrElse[String](CosmosDBConfig.BulkImportMaxConcurrencyPerPartitionRange, String.valueOf(CosmosDBConfig.DefaultBulkImportMaxConcurrencyPerPartitionRange))
       .toInt
-
-    // Delay the start as the number of tasks grow to avoid throttling at initialization
-    val maxDelaySec: Int = (partitionCount / clientInitDelay) + (if (partitionCount % clientInitDelay > 0) 1 else 0)
-    if (maxDelaySec > 0) {
-      val seconds = random.nextInt(maxDelaySec)
-      logInfo(s"Delaying operation by ${seconds}s to stagger partitions.")
-      TimeUnit.SECONDS.sleep(seconds)
-    }
 
     CosmosDBSpark.lastUpsertSetting = Some(upsert)
     CosmosDBSpark.lastWritingBatchSize = Some(writingBatchSize)

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/config/CosmosDBConfig.scala
@@ -101,7 +101,6 @@ object CosmosDBConfig {
 
   // Write path related config
   val Upsert = "upsert"
-  val ClientInitDelay = "clientinitdelay"
   val RootPropertyToSave = "rootpropertytosave"
   val PreserveNullInWrite = "preservenullinwrite"
 
@@ -161,8 +160,6 @@ object CosmosDBConfig {
   val DefaultBulkImport = true
   val DefaultBulkUpdate = false
   val DefaultMaxMiniBatchUpdateCount = 500
-  val DefaultClientInitDelay = 10
-
   val DefaultAdlUseGuidForId = true
   val DefaultAdlUseGuidForPk = true
   val DefaultAdlMaxFileCount: Int = Int.MaxValue


### PR DESCRIPTION
The change is possible now because we had introduced the CosmosDBConnectionCache - so we only need to initialize a single CosmosClient (with the metadata requests impacting master RU budget) per executor and follow a singleton pattern otherwise.