### PR TITLE
Adding BulkSink for streaming writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.7.0
+- Adds a new sink for streaming writes "com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBBulkSinkProvider" that will use bulk ingestion internally
+
 ### 3.6.8
 - Reduces the performance overhead when a Spark DataFrame as many partitions - especially when using  Cosmos DB as a sink in Spark Streaming scenarios
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-cosmosdb-spark_2.4.0_2.11</artifactId>
     <packaging>jar</packaging>
-    <version>3.6.8</version>
+    <version>3.7.0</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Spark Connector for Microsoft Azure CosmosDB</description>
     <url>http://azure.microsoft.com/en-us/services/documentdb/</url>

--- a/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBBulkSinkProvider.scala
+++ b/src/main/scala/com/microsoft/azure/cosmosdb/spark/streaming/CosmosDBBulkSinkProvider.scala
@@ -20,9 +20,23 @@
   * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   * SOFTWARE.
   */
-package com.microsoft.azure.cosmosdb.spark
+package com.microsoft.azure.cosmosdb.spark.streaming
 
-object Constants {
-  val currentVersion = "2.4.0_2.11-3.7.0"
-  val userAgentSuffix = s" SparkConnector/$currentVersion"
+import com.microsoft.azure.cosmosdb.spark.CosmosDBLoggingTrait
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
+import org.apache.spark.sql.streaming.OutputMode
+
+class CosmosDBBulkSinkProvider extends DataSourceRegister
+  with StreamSinkProvider with CosmosDBLoggingTrait {
+
+  override def shortName(): String = "CosmosDBBulkSinkProvider"
+
+  override def createSink(sqlContext: SQLContext,
+                          parameters: Map[String, String],
+                          partitionColumns: Seq[String],
+                          outputMode: OutputMode): Sink = {
+    new CosmosDBBulkSink(sqlContext, parameters)
+  }
 }


### PR DESCRIPTION
Customer is facing some latency issues because their streaming workload at steady-state is small (like about 4 documents/second) but during some periods of the day can goo to tens -of-thousand of documents - when the AsyncConnection based write stream implementation doesn't work fast and robust enough.
An initial attempt to use readStream.forEachBatch and then write each micro batch to cosmos via batch write works but is showing higher latency for the small stead-state workload. 
From my own tests the latency with the BulkSink can be improved by 200-300ms (still about 200ms slower than point writes via Async Connection but that is about the expected ballpark).